### PR TITLE
Detector de BPM y tonalidad de nivel profesional

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "validate:audio": "node scripts/validate-audio-engine.mjs"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.3.0",

--- a/frontend/scripts/debug-tempo.mjs
+++ b/frontend/scripts/debug-tempo.mjs
@@ -1,0 +1,22 @@
+// Debug harness: prints per-candidate metrical-level metrics.
+//   node scripts/debug-tempo.mjs
+globalThis.__TEMPO_DEBUG = true
+
+const { estimateTempo } = await import('../src/utils/tempoEngine.js')
+const { SR, synthTrack } = await import('./synth-tracks.mjs')
+const { MODE_MINOR, MODE_MAJOR } = await import('../src/utils/musicTheory.js')
+
+const CASES = [
+  { name: 'Techno 140', bpm: 140, keyPc: 9, mode: MODE_MINOR, pattern: 'fourFloor', seed: 22 },
+  { name: 'Hip-hop 95', bpm: 95, keyPc: 7, mode: MODE_MINOR, pattern: 'hiphop', seed: 33 },
+  { name: 'Halftime 87.5', bpm: 87.5, keyPc: 1, mode: MODE_MINOR, pattern: 'hiphop', seed: 44 },
+  { name: 'Downtempo 70', bpm: 70, keyPc: 10, mode: MODE_MAJOR, pattern: 'hiphop', seed: 88 },
+  { name: 'Dance 110', bpm: 110, keyPc: 3, mode: MODE_MAJOR, pattern: 'fourFloor', seed: 66 },
+]
+
+for (const c of CASES) {
+  console.log(`\n=== ${c.name} (esperado ${c.bpm}) ===`)
+  const pcm = synthTrack(c)
+  const r = estimateTempo(pcm, SR)
+  console.log(`  → bpm=${r.bpm.toFixed(2)} conf=${r.confidence} alt=${r.alt ? r.alt.toFixed(1) : '—'}`)
+}

--- a/frontend/scripts/synth-tracks.mjs
+++ b/frontend/scripts/synth-tracks.mjs
@@ -1,0 +1,197 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Synthetic test-track generator shared by the validation suite and debug
+// tools. Everything is deterministic (seeded RNG) and rendered at the
+// engine's working sample rate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { ENGINE_SAMPLE_RATE } from '../src/utils/audioEngine.js'
+import { MODE_MINOR } from '../src/utils/musicTheory.js'
+
+export const SR = ENGINE_SAMPLE_RATE
+
+// Deterministic RNG (mulberry32) so runs are reproducible.
+export function makeRng (seed) {
+  let a = seed >>> 0
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const noteHz = (midi, detune) => 440 * Math.pow(2, (midi - 69) / 12) * detune
+
+// ─── Instrument renderers (additive, into a shared buffer) ──────────────────
+function addKick (buf, t0, vel) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(0.35 * SR)
+  const tau = 0.04
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    const phase = 2 * Math.PI * (45 * t + 100 * tau * (1 - Math.exp(-t / tau)))
+    buf[n0 + i] += vel * Math.sin(phase) * Math.exp(-t / 0.13)
+  }
+}
+
+function addSnare (buf, t0, vel, rng) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(0.22 * SR)
+  let lp = 0
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    const white = rng() * 2 - 1
+    lp += 0.25 * (white - lp) // crude band shaping
+    const noise = (white - lp) * 0.7
+    const tone = 0.5 * Math.sin(2 * Math.PI * 186 * t) * Math.exp(-t / 0.05)
+    buf[n0 + i] += vel * 0.8 * ((noise * Math.exp(-t / 0.08)) + tone)
+  }
+}
+
+function addHat (buf, t0, vel, rng) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(0.06 * SR)
+  let prev = 0
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    const white = rng() * 2 - 1
+    const hp = white - prev // 1st-order highpass
+    prev = white
+    buf[n0 + i] += vel * 0.32 * hp * Math.exp(-t / 0.022)
+  }
+}
+
+function addBass (buf, t0, midi, dur, vel, detune) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(dur * SR)
+  const f = noteHz(midi, detune)
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    const env = Math.exp(-t / 0.18) * Math.min(1, t / 0.005)
+    buf[n0 + i] += vel * 0.9 * env * (Math.sin(2 * Math.PI * f * t) + 0.4 * Math.sin(4 * Math.PI * f * t))
+  }
+}
+
+function addPadNote (buf, t0, midi, dur, vel, detune) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(dur * SR)
+  const f = noteHz(midi, detune)
+  const rel = Math.max(1, len - Math.floor(0.1 * SR))
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    let s = 0
+    for (let h = 1; h <= 6; h++) s += Math.sin(2 * Math.PI * h * f * t) / Math.pow(h, 1.3)
+    let env = Math.min(1, t / 0.03)
+    if (i > rel) env *= 1 - (i - rel) / (len - rel)
+    buf[n0 + i] += vel * env * s
+  }
+}
+
+function addArpNote (buf, t0, midi, vel, detune) {
+  const n0 = Math.floor(t0 * SR)
+  const len = Math.floor(0.12 * SR)
+  const f = noteHz(midi, detune)
+  for (let i = 0; i < len && n0 + i < buf.length; i++) {
+    const t = i / SR
+    buf[n0 + i] += vel * 0.3 * Math.sin(2 * Math.PI * f * t) * Math.exp(-t / 0.05)
+  }
+}
+
+// ─── Track synthesis ─────────────────────────────────────────────────────────
+// Cadential progressions with an unambiguous tonic. The 'axis' progression
+// (i–VI–III–VII) is deliberately relative-ambiguous, used by one test case.
+const PROGRESSIONS = {
+  cadentialMinor: [[0, 'm'], [5, 'm'], [7, 'M'], [0, 'm']], // i  iv V  i (harmonic V)
+  cadentialMajor: [[0, 'M'], [5, 'M'], [7, 'M'], [0, 'M']], // I  IV V  I
+  axisMinor: [[0, 'm'], [8, 'M'], [3, 'M'], [10, 'M']],     // i  VI III VII
+}
+
+const PATTERNS = {
+  fourFloor: { kick: [0, 1, 2, 3], snare: [1, 3], hat: [0.5, 1.5, 2.5, 3.5], swing: 0 },
+  breakbeat: { kick: [0, 1.75, 2.5], snare: [1, 3], hat: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5], swing: 0 },
+  hiphop: { kick: [0, 0.75, 2.25], snare: [1, 3], hat: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5], swing: 0.07 },
+}
+
+export function synthTrack ({
+  bpm, dur = 50, keyPc, mode, pattern = 'fourFloor', detuneCents = 0,
+  progression, seed = 1234, bassEighths = false, noDrums = false,
+  noBass = false, introSec = 0,
+}) {
+  const n = Math.floor(dur * SR)
+  const buf = new Float32Array(n)
+  const rng = makeRng(seed)
+  const detune = Math.pow(2, detuneCents / 1200)
+  const beat = 60 / bpm
+  const bar = 4 * beat
+  const nBars = Math.floor(dur / bar)
+  const rootMidi = 48 + keyPc
+  const prog = PROGRESSIONS[progression ?? (mode === MODE_MINOR ? 'cadentialMinor' : 'cadentialMajor')]
+  const pat = PATTERNS[pattern]
+  const triad = (q) => (q === 'M' ? [0, 4, 7] : [0, 3, 7])
+  const human = () => (rng() - 0.5) * 0.006
+  const velj = () => 0.9 + 0.2 * rng()
+
+  for (let b = 0; b < nBars; b++) {
+    const t0 = b * bar
+    const inIntro = t0 < introSec // pads only (beatless intro)
+    const [deg, quality] = prog[b % prog.length]
+    const chordRoot = rootMidi + deg
+    const tones = triad(quality)
+
+    // Pad chord (triad + octave) across the bar
+    for (const iv of tones) addPadNote(buf, t0 + human(), chordRoot + iv, bar, 0.16 * velj(), detune)
+    addPadNote(buf, t0 + human(), chordRoot + 12, bar, 0.12 * velj(), detune)
+
+    // Bass: chord root, one/two octaves down — quarters or rolling eighths
+    if (!noBass && !inIntro) {
+      const steps = bassEighths ? 8 : 4
+      const stepBeat = bassEighths ? 0.5 : 1
+      for (let q = 0; q < steps; q++) {
+        addBass(buf, t0 + q * stepBeat * beat + human(), chordRoot - 24, stepBeat * beat * 0.6, velj(), detune)
+      }
+    }
+
+    // Arp: eighth notes cycling chord tones, two octaves up
+    if (!inIntro) {
+      for (let e = 0; e < 8; e++) {
+        const tone = tones[e % tones.length]
+        addArpNote(buf, t0 + e * 0.5 * beat + human(), chordRoot + tone + 24, velj(), detune)
+      }
+    }
+
+    // Drums
+    if (!noDrums && !inIntro) {
+      for (const kb of pat.kick) addKick(buf, t0 + kb * beat + human(), velj())
+      for (const sb of pat.snare) addSnare(buf, t0 + sb * beat + human(), velj(), rng)
+      for (const hb of pat.hat) {
+        const swung = hb % 1 !== 0 ? hb + pat.swing : hb
+        addHat(buf, t0 + swung * beat + human(), velj(), rng)
+      }
+    }
+  }
+
+  // Gentle noise floor + soft clip + normalize
+  let lp = 0
+  let peak = 0
+  for (let i = 0; i < n; i++) {
+    lp += 0.02 * ((rng() * 2 - 1) - lp)
+    buf[i] = Math.tanh(0.8 * (buf[i] + lp * 0.02))
+    const a = Math.abs(buf[i])
+    if (a > peak) peak = a
+  }
+  if (peak > 0) for (let i = 0; i < n; i++) buf[i] = (buf[i] / peak) * 0.95
+  return buf
+}
+
+export function synthNoise (dur, seed = 7) {
+  const rng = makeRng(seed)
+  const n = Math.floor(dur * SR)
+  const buf = new Float32Array(n)
+  let lp = 0
+  for (let i = 0; i < n; i++) {
+    lp += 0.15 * ((rng() * 2 - 1) - lp)
+    buf[i] = lp * 1.5
+  }
+  return buf
+}
+

--- a/frontend/scripts/validate-audio-engine.mjs
+++ b/frontend/scripts/validate-audio-engine.mjs
@@ -1,0 +1,111 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Ground-truth validation suite for the audio analysis engine.
+//
+//   node scripts/validate-audio-engine.mjs
+//
+// Synthesizes realistic multi-genre test tracks (drums + bass + chords + arp,
+// deterministic humanization) whose BPM and key are known exactly, runs the
+// production engine on them and asserts the results. Exit code 1 on failure.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { analyzeAudioData } from '../src/utils/audioEngine.js'
+import { NOTE_NAMES, MODE_MAJOR, MODE_MINOR, relativeKey } from '../src/utils/musicTheory.js'
+import { SR, synthTrack, synthNoise } from './synth-tracks.mjs'
+
+// ─── Test matrix ─────────────────────────────────────────────────────────────
+const CASES = [
+  { name: 'House 128 · F menor', bpm: 128, keyPc: 5, mode: MODE_MINOR, pattern: 'fourFloor', seed: 11 },
+  { name: 'Techno 140 · A menor', bpm: 140, keyPc: 9, mode: MODE_MINOR, pattern: 'fourFloor', seed: 22 },
+  { name: 'Hip-hop 95 · G menor', bpm: 95, keyPc: 7, mode: MODE_MINOR, pattern: 'hiphop', seed: 33 },
+  { name: 'Halftime 87.5 · C# menor', bpm: 87.5, keyPc: 1, mode: MODE_MINOR, pattern: 'hiphop', seed: 44 },
+  { name: 'DnB 174 · F# menor', bpm: 174, keyPc: 6, mode: MODE_MINOR, pattern: 'breakbeat', seed: 55, allowHalfTempo: true },
+  { name: 'Dance 110 · Eb mayor', bpm: 110, keyPc: 3, mode: MODE_MAJOR, pattern: 'fourFloor', seed: 66 },
+  { name: 'Breaks 150 · B menor', bpm: 150, keyPc: 11, mode: MODE_MINOR, pattern: 'breakbeat', seed: 77 },
+  { name: 'Downtempo 70 · Bb mayor', bpm: 70, keyPc: 10, mode: MODE_MAJOR, pattern: 'hiphop', seed: 88 },
+  { name: 'Axis loop 124 · A menor (relativa ok)', bpm: 124, keyPc: 9, mode: MODE_MINOR, pattern: 'fourFloor', progression: 'axisMinor', seed: 99, allowRelative: true },
+  { name: 'Detune +30c 122 · D menor', bpm: 122, keyPc: 2, mode: MODE_MINOR, pattern: 'fourFloor', detuneCents: 30, seed: 111, expectCents: 30 },
+  { name: 'Detune −25c 133 · E mayor', bpm: 133, keyPc: 4, mode: MODE_MAJOR, pattern: 'fourFloor', detuneCents: -25, seed: 122, expectCents: -25 },
+  { name: 'Trance 138 bajo en 8as · F menor', bpm: 138, keyPc: 5, mode: MODE_MINOR, pattern: 'fourFloor', bassEighths: true, seed: 133 },
+  { name: 'Sin batería 90 · A mayor', bpm: 90, keyPc: 9, mode: MODE_MAJOR, noDrums: true, noBass: true, seed: 144, allowBpmSet: [90, 180], skipConfCheck: true },
+  { name: 'Intro 20s + House 126 · Ab menor', bpm: 126, keyPc: 8, mode: MODE_MINOR, pattern: 'fourFloor', introSec: 20, dur: 65, seed: 155 },
+]
+
+function checkCase (c, r) {
+  const failures = []
+
+  // BPM: exact metrical level required (alternate levels only if flagged).
+  const targets = c.allowBpmSet ?? [c.bpm]
+  const bpmOk = targets.some(t => Math.abs(r.bpm - t) <= 0.6)
+  const halfOk = c.allowHalfTempo && Math.abs(r.bpm - c.bpm / 2) <= 0.4
+  if (!bpmOk && !halfOk) failures.push(`bpm ${r.bpm} ≠ ${targets.join('/')}`)
+
+  // Key: exact, or relative when the progression is genuinely ambiguous.
+  const expNote = NOTE_NAMES[c.keyPc]
+  const keyExact = r.key === expNote && r.mode === c.mode
+  let keyOk = keyExact
+  if (!keyOk && c.allowRelative) {
+    const rel = relativeKey(c.keyPc, c.mode)
+    keyOk = r.key === NOTE_NAMES[rel.pitchClass] && r.mode === rel.mode
+  }
+  if (!keyOk) failures.push(`key ${r.key} ${r.mode} ≠ ${expNote} ${c.mode}`)
+
+  if (c.expectCents !== undefined && Math.abs(r.tuningCents - c.expectCents) > 8) {
+    failures.push(`tuning ${r.tuningCents}c ≠ ${c.expectCents}c`)
+  }
+
+  if (!c.skipConfCheck && bpmOk && r.bpmConfidence < 70) failures.push(`bpmConf baja: ${r.bpmConfidence}`)
+  if (keyExact && r.keyConfidence < 60) failures.push(`keyConf baja: ${r.keyConfidence}`)
+
+  return failures
+}
+
+async function main () {
+  let failed = 0
+  const rows = []
+
+  for (const c of CASES) {
+    const pcm = synthTrack(c)
+    const t0 = Date.now()
+    const r = analyzeAudioData(pcm, SR, { duration: pcm.length / SR })
+    const ms = Date.now() - t0
+    const failures = checkCase(c, r)
+    if (failures.length) failed++
+    rows.push({
+      caso: c.name,
+      esperado: `${c.bpm} · ${NOTE_NAMES[c.keyPc]} ${c.mode}`,
+      bpm: `${r.bpmDisplay} (${r.bpmConfidence}%)${r.bpmAltDisplay ? ` alt:${r.bpmAltDisplay}` : ''}`,
+      key: `${r.key} ${r.mode} ${r.camelot} (${r.keyConfidence}%)`,
+      afin: `${r.tuningCents}c`,
+      per: r.metrics.tempo ? r.metrics.tempo.medStrength?.toFixed(3) : '—',
+      ms,
+      estado: failures.length ? `FAIL: ${failures.join('; ')}` : 'OK',
+    })
+  }
+
+  // Edge cases: must degrade gracefully, never crash or overclaim.
+  const noise = analyzeAudioData(synthNoise(30), SR, {})
+  const noiseOk = noise.bpmConfidence < 60 && noise.keyConfidence < 55
+  rows.push({
+    caso: 'Ruido 30 s (sin música)',
+    esperado: 'confianzas bajas',
+    bpm: `${noise.bpmDisplay} (${noise.bpmConfidence}%)`,
+    key: `${noise.key} ${noise.mode} (${noise.keyConfidence}%)`,
+    afin: `${noise.tuningCents}c`,
+    ms: 0,
+    estado: noiseOk ? 'OK' : 'FAIL: sobre-confianza en ruido',
+  })
+  if (!noiseOk) failed++
+
+  let silentOk = false
+  try { analyzeAudioData(new Float32Array(SR * 10), SR, {}) } catch (e) { silentOk = e.message === 'AUDIO_SILENT' }
+  let shortOk = false
+  try { analyzeAudioData(new Float32Array(SR * 2).fill(0.1), SR, {}) } catch (e) { shortOk = e.message === 'AUDIO_TOO_SHORT' }
+  rows.push({ caso: 'Silencio / clip corto', esperado: 'errores tipados', bpm: '—', key: '—', afin: '—', ms: 0, estado: silentOk && shortOk ? 'OK' : 'FAIL' })
+  if (!silentOk || !shortOk) failed++
+
+  console.table(rows)
+  console.log(failed === 0 ? `✔ ${rows.length} casos OK` : `✘ ${failed} casos FALLAN`)
+  process.exit(failed === 0 ? 0 : 1)
+}
+
+main()

--- a/frontend/src/components/Tools/AudioAnalyzer/AudioAnalyzer.jsx
+++ b/frontend/src/components/Tools/AudioAnalyzer/AudioAnalyzer.jsx
@@ -1,15 +1,36 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { analyzeAudio } from '../../../utils/audioAnalysis.js'
+import { analyzeAudioFile, disposeAnalyzer } from '../../../utils/audioAnalysis.js'
 import styles from './AudioAnalyzer.module.css'
 
 const ACCEPTED = ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/flac', 'audio/mp4', 'audio/aac', 'audio/x-m4a']
 const MAX_MB   = 80
 
+const STAGE_LABELS = {
+  decode: 'Decodificando audio',
+  bpm:    'Detectando BPM',
+  key:    'Analizando tonalidad',
+  done:   'Finalizando',
+}
+
+const MODE_ES = { major: 'mayor', minor: 'menor' }
+const REL_ES  = { relative: 'relativa', fifth: 'quinta', parallel: 'paralela', other: '', same: '' }
+
+const AUDIO_ERROR_MESSAGES = {
+  AUDIO_TOO_SHORT: 'El archivo es demasiado corto para un análisis fiable (mínimo ~3 segundos).',
+  AUDIO_SILENT:    'El archivo parece estar en silencio.',
+}
+
 function formatDuration (secs) {
   const m = Math.floor(secs / 60)
   const s = Math.floor(secs % 60)
   return `${m}:${String(s).padStart(2, '0')}`
+}
+
+function formatTuning (hz, cents) {
+  if (!hz) return null
+  const sign = cents > 0 ? '+' : ''
+  return cents !== 0 ? `${hz} Hz (${sign}${cents} cents)` : `${hz} Hz`
 }
 
 export default function AudioAnalyzer () {
@@ -18,13 +39,18 @@ export default function AudioAnalyzer () {
   const [results,  setResults]  = useState(null)
   const [error,    setError]    = useState('')
   const [dragging, setDragging] = useState(false)
+  const [progress, setProgress] = useState({ stage: 'decode', pct: 0 })
   const inputRef = useRef(null)
+  const jobRef   = useRef(0)
+
+  useEffect(() => () => { jobRef.current++; disposeAnalyzer() }, [])
 
   const acceptFile = useCallback((f) => {
     if (!f) return
     const okType = ACCEPTED.some(t => f.type === t) || f.name.match(/\.(mp3|wav|ogg|flac|m4a|aac)$/i)
     if (!okType) { setError('Formato no compatible. Usa MP3, WAV, OGG, FLAC o M4A.'); setPhase('error'); return }
     if (f.size > MAX_MB * 1024 * 1024) { setError(`El archivo supera el límite de ${MAX_MB} MB.`); setPhase('error'); return }
+    jobRef.current++
     setFile(f)
     setResults(null)
     setError('')
@@ -38,21 +64,34 @@ export default function AudioAnalyzer () {
 
   const handleAnalyze = async () => {
     if (!file) return
+    const job = ++jobRef.current
     setPhase('analyzing')
-    // Yield to React so loading state renders before heavy computation
-    await new Promise(r => setTimeout(r, 60))
+    setProgress({ stage: 'decode', pct: 0 })
     try {
-      const buf  = await file.arrayBuffer()
-      const data = await analyzeAudio(buf)
+      const data = await analyzeAudioFile(file, {
+        onProgress: (p) => { if (jobRef.current === job) setProgress(p) },
+      })
+      if (jobRef.current !== job) return
       setResults(data)
       setPhase('done')
     } catch (e) {
-      setError('No se pudo analizar el archivo. Comprueba que es un audio válido.')
+      if (jobRef.current !== job) return
+      setError(AUDIO_ERROR_MESSAGES[e.message] ?? 'No se pudo analizar el archivo. Comprueba que es un audio válido.')
       setPhase('error')
     }
   }
 
-  const reset = () => { setPhase('idle'); setFile(null); setResults(null); setError(''); if (inputRef.current) inputRef.current.value = '' }
+  const reset = () => {
+    jobRef.current++
+    setPhase('idle')
+    setFile(null)
+    setResults(null)
+    setError('')
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  const keyAlt = results?.keyAlternative
+  const keyAltRel = keyAlt ? REL_ES[keyAlt.relationship] ?? '' : ''
 
   return (
     <div className={styles.aa}>
@@ -101,7 +140,7 @@ export default function AudioAnalyzer () {
       {/* ── Actions ── */}
       {(phase === 'ready' || phase === 'done') && (
         <div className={styles.aa__actions}>
-          <button className={styles.aa__btn} onClick={handleAnalyze} disabled={phase === 'analyzing'}>
+          <button className={styles.aa__btn} onClick={handleAnalyze}>
             <FontAwesomeIcon icon={['fas', 'gauge-high']} />
             {phase === 'done' ? 'Analizar de nuevo' : 'Analizar'}
           </button>
@@ -112,12 +151,15 @@ export default function AudioAnalyzer () {
         </div>
       )}
 
-      {/* ── Analyzing ── */}
+      {/* ── Analyzing (staged progress) ── */}
       {phase === 'analyzing' && (
         <div className={styles.aa__loading}>
           <FontAwesomeIcon icon={['fas', 'spinner']} spin className={styles.aa__spinner} />
-          <p className={styles.aa__loadingTitle}>Analizando…</p>
-          <p className={styles.aa__loadingSub}>Calculando BPM y tonalidad</p>
+          <p className={styles.aa__loadingTitle}>{STAGE_LABELS[progress.stage] ?? 'Analizando'}…</p>
+          <div className={styles.aa__progress}>
+            <div className={styles.aa__progressFill} style={{ width: `${progress.pct}%` }} />
+          </div>
+          <p className={styles.aa__loadingSub}>{progress.pct}% · análisis local, tu audio no se sube a ningún servidor</p>
         </div>
       )}
 
@@ -128,11 +170,14 @@ export default function AudioAnalyzer () {
             <span className={styles.aa__cardLabel}>
               <FontAwesomeIcon icon={['fas', 'gauge-high']} /> BPM
             </span>
-            <span className={styles.aa__cardValue}>{results.bpm}</span>
+            <span className={styles.aa__cardValue}>{results.bpmDisplay}</span>
             <div className={styles.aa__bar}>
               <div className={styles.aa__barFill} style={{ width: `${results.bpmConfidence}%` }} />
             </div>
             <span className={styles.aa__cardHint}>{results.bpmConfidence}% de confianza</span>
+            {results.bpmAltDisplay && (
+              <span className={styles.aa__cardAlt}>Alternativa: {results.bpmAltDisplay} BPM</span>
+            )}
           </div>
 
           <div className={styles.aa__card}>
@@ -141,12 +186,19 @@ export default function AudioAnalyzer () {
             </span>
             <span className={styles.aa__cardValue}>
               {results.key}
-              <span className={styles.aa__cardMode}>{results.mode}</span>
+              <span className={styles.aa__cardMode}>{MODE_ES[results.mode] ?? results.mode}</span>
+              {results.camelot && <span className={styles.aa__camelot} title="Notación Camelot (mezcla armónica)">{results.camelot}</span>}
             </span>
             <div className={styles.aa__bar}>
               <div className={styles.aa__barFill} style={{ width: `${results.keyConfidence}%` }} />
             </div>
             <span className={styles.aa__cardHint}>{results.keyConfidence}% de confianza</span>
+            {keyAlt && (
+              <span className={styles.aa__cardAlt}>
+                Alternativa: {keyAlt.note} {MODE_ES[keyAlt.mode] ?? keyAlt.mode}
+                {keyAltRel ? ` (${keyAltRel})` : ''} · {keyAlt.camelot}
+              </span>
+            )}
           </div>
 
           <div className={`${styles.aa__card} ${styles['aa__card--meta']}`}>
@@ -155,7 +207,10 @@ export default function AudioAnalyzer () {
             </span>
             <span className={styles.aa__metaName}>{file.name}</span>
             <span className={styles.aa__metaDur}>{formatDuration(results.duration)}</span>
-            <span className={styles.aa__cardHint}>Análisis del fragmento central</span>
+            {results.tuningHz && (
+              <span className={styles.aa__cardHint}>Afinación: {formatTuning(results.tuningHz, results.tuningCents)}</span>
+            )}
+            <span className={styles.aa__cardHint}>Análisis 100% local</span>
           </div>
         </div>
       )}

--- a/frontend/src/components/Tools/AudioAnalyzer/AudioAnalyzer.module.css
+++ b/frontend/src/components/Tools/AudioAnalyzer/AudioAnalyzer.module.css
@@ -183,6 +183,23 @@
   margin: 0;
 }
 
+/* Staged progress bar */
+.aa__progress {
+  width: min(320px, 80%);
+  height: 6px;
+  background: #1e1e1e;
+  border-radius: 3px;
+  overflow: hidden;
+  margin: 0.5rem 0 0.25rem;
+}
+
+.aa__progressFill {
+  height: 100%;
+  background: #ff003c;
+  border-radius: 3px;
+  transition: width 0.25s ease;
+}
+
 /* ── Results ── */
 .aa__results {
   display: grid;
@@ -243,6 +260,26 @@
   font-weight: 500;
   color: #666;
   letter-spacing: 0;
+}
+
+/* Camelot wheel chip (harmonic mixing notation) */
+.aa__camelot {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: #ff5c7c;
+  background: rgba(255, 0, 60, 0.12);
+  border: 1px solid rgba(255, 0, 60, 0.35);
+  border-radius: 6px;
+  padding: 0.2rem 0.45rem;
+  align-self: center;
+}
+
+/* Secondary interpretation (octave / relative key) */
+.aa__cardAlt {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 0.15rem;
 }
 
 /* Confidence bar */

--- a/frontend/src/pages/Herramientas.jsx
+++ b/frontend/src/pages/Herramientas.jsx
@@ -21,7 +21,7 @@ const TOOLS = [
   {
     id: 'audio-analyzer',
     label: 'Detector BPM / Tono',
-    description: 'Analiza el BPM y la tonalidad de cualquier canción directamente desde tu dispositivo.',
+    description: 'Detección profesional de BPM y tonalidad (con notación Camelot), 100% local en tu dispositivo.',
     icon: 'gauge-high',
     component: AudioAnalyzer,
   },

--- a/frontend/src/tests/audioEngine.test.js
+++ b/frontend/src/tests/audioEngine.test.js
@@ -1,0 +1,80 @@
+import { analyzeAudioData, ENGINE_SAMPLE_RATE } from '../utils/audioEngine.js'
+
+const SR = ENGINE_SAMPLE_RATE
+
+// Minimal deterministic synth: kick + bass on every beat, cadential minor
+// chord pads (i–iv–V–i) — enough signal for both engines in a short clip.
+function synthTrack (bpm, rootPc, durSec) {
+  const n = Math.floor(durSec * SR)
+  const buf = new Float32Array(n)
+  const beat = 60 / bpm
+  const bar = beat * 4
+  const rootMidi = 48 + rootPc
+  const hz = (midi) => 440 * Math.pow(2, (midi - 69) / 12)
+  const prog = [[0, [0, 3, 7]], [5, [0, 3, 7]], [7, [0, 4, 7]], [0, [0, 3, 7]]]
+
+  const nBars = Math.floor(durSec / bar)
+  for (let b = 0; b < nBars; b++) {
+    const t0 = b * bar
+    const [deg, triad] = prog[b % 4]
+    const chordRoot = rootMidi + deg
+
+    for (const iv of triad) {
+      const f = hz(chordRoot + iv)
+      const n0 = Math.floor(t0 * SR)
+      const len = Math.floor(bar * SR)
+      for (let i = 0; i < len && n0 + i < n; i++) {
+        const t = i / SR
+        const env = Math.min(1, t / 0.02) * (i < len - 500 ? 1 : (len - i) / 500)
+        buf[n0 + i] += 0.12 * env * (
+          Math.sin(2 * Math.PI * f * t) +
+          0.5 * Math.sin(4 * Math.PI * f * t) +
+          0.25 * Math.sin(6 * Math.PI * f * t)
+        )
+      }
+    }
+
+    for (let q = 0; q < 4; q++) {
+      const tb = t0 + q * beat
+      const n0 = Math.floor(tb * SR)
+      // Kick: 100→45 Hz sweep
+      const kLen = Math.floor(0.3 * SR)
+      for (let i = 0; i < kLen && n0 + i < n; i++) {
+        const t = i / SR
+        const phase = 2 * Math.PI * (45 * t + 100 * 0.04 * (1 - Math.exp(-t / 0.04)))
+        buf[n0 + i] += Math.sin(phase) * Math.exp(-t / 0.12)
+      }
+      // Bass pluck on the chord root
+      const bLen = Math.floor(0.5 * beat * SR)
+      const bf = hz(chordRoot - 24)
+      for (let i = 0; i < bLen && n0 + i < n; i++) {
+        const t = i / SR
+        buf[n0 + i] += 0.8 * Math.exp(-t / 0.15) * Math.sin(2 * Math.PI * bf * t)
+      }
+    }
+  }
+  return buf
+}
+
+describe('audioEngine (end-to-end on synthetic ground truth)', () => {
+  it('detects 120 BPM / A minor on a clean synthetic loop', () => {
+    const pcm = synthTrack(120, 9, 25)
+    const r = analyzeAudioData(pcm, SR, { duration: 25 })
+    expect(Math.abs(r.bpm - 120)).toBeLessThanOrEqual(0.6)
+    expect(r.key).toBe('A')
+    expect(r.mode).toBe('minor')
+    expect(r.camelot).toBe('8A')
+    expect(r.bpmConfidence).toBeGreaterThanOrEqual(60)
+    expect(r.keyConfidence).toBeGreaterThanOrEqual(55)
+  })
+
+  it('rejects silent audio with a typed error', () => {
+    expect(() => analyzeAudioData(new Float32Array(SR * 10), SR, {}))
+      .toThrow('AUDIO_SILENT')
+  })
+
+  it('rejects too-short audio with a typed error', () => {
+    expect(() => analyzeAudioData(new Float32Array(SR * 2).fill(0.1), SR, {}))
+      .toThrow('AUDIO_TOO_SHORT')
+  })
+})

--- a/frontend/src/tests/musicTheory.test.js
+++ b/frontend/src/tests/musicTheory.test.js
@@ -1,0 +1,87 @@
+import {
+  toCamelot,
+  toOpenKey,
+  snapBpm,
+  relativeKey,
+  keyRelationship,
+  foldBpm,
+  keyLabel,
+  MODE_MAJOR,
+  MODE_MINOR,
+} from '../utils/musicTheory.js'
+
+describe('musicTheory', () => {
+  describe('toCamelot', () => {
+    it('maps the canonical anchors of the Camelot wheel', () => {
+      expect(toCamelot(9, MODE_MINOR)).toBe('8A')   // A minor
+      expect(toCamelot(0, MODE_MAJOR)).toBe('8B')   // C major
+      expect(toCamelot(8, MODE_MINOR)).toBe('1A')   // Ab minor
+      expect(toCamelot(11, MODE_MAJOR)).toBe('1B')  // B major
+      expect(toCamelot(4, MODE_MAJOR)).toBe('12B')  // E major
+      expect(toCamelot(1, MODE_MINOR)).toBe('12A')  // Db minor
+      expect(toCamelot(7, MODE_MAJOR)).toBe('9B')   // G major (fifth up = +1)
+    })
+
+    it('relative keys share the same wheel number', () => {
+      for (let pc = 0; pc < 12; pc++) {
+        const rel = relativeKey(pc, MODE_MAJOR)
+        const major = toCamelot(pc, MODE_MAJOR)
+        const minor = toCamelot(rel.pitchClass, rel.mode)
+        expect(parseInt(minor, 10)).toBe(parseInt(major, 10))
+      }
+    })
+  })
+
+  it('toOpenKey matches the Traktor convention', () => {
+    expect(toOpenKey(0, MODE_MAJOR)).toBe('1d') // C major
+    expect(toOpenKey(9, MODE_MINOR)).toBe('1m') // A minor
+  })
+
+  describe('snapBpm', () => {
+    it('snaps near-integers', () => {
+      expect(snapBpm(127.98)).toEqual({ value: 128, display: '128' })
+      expect(snapBpm(140.2)).toEqual({ value: 140, display: '140' })
+    })
+    it('keeps musically-real half BPMs', () => {
+      expect(snapBpm(87.46)).toEqual({ value: 87.5, display: '87.5' })
+    })
+    it('keeps one decimal for odd tempos', () => {
+      expect(snapBpm(93.27)).toEqual({ value: 93.3, display: '93.3' })
+    })
+    it('handles invalid input', () => {
+      expect(snapBpm(0).display).toBe('—')
+      expect(snapBpm(NaN).display).toBe('—')
+    })
+  })
+
+  it('relativeKey is a proper involution', () => {
+    expect(relativeKey(0, MODE_MAJOR)).toEqual({ pitchClass: 9, mode: MODE_MINOR })
+    expect(relativeKey(9, MODE_MINOR)).toEqual({ pitchClass: 0, mode: MODE_MAJOR })
+    for (let pc = 0; pc < 12; pc++) {
+      const back = relativeKey(relativeKey(pc, MODE_MINOR).pitchClass, MODE_MAJOR)
+      expect(back).toEqual({ pitchClass: pc, mode: MODE_MINOR })
+    }
+  })
+
+  it('keyRelationship names the classic confusions', () => {
+    const am = { pitchClass: 9, mode: MODE_MINOR }
+    const c = { pitchClass: 0, mode: MODE_MAJOR }
+    const g = { pitchClass: 7, mode: MODE_MAJOR }
+    const cm = { pitchClass: 0, mode: MODE_MINOR }
+    expect(keyRelationship(am, c)).toBe('relative')
+    expect(keyRelationship(c, g)).toBe('fifth')
+    expect(keyRelationship(c, cm)).toBe('parallel')
+    expect(keyRelationship(c, c)).toBe('same')
+  })
+
+  it('foldBpm folds by octaves into range', () => {
+    expect(foldBpm(64)).toBe(128)
+    expect(foldBpm(200)).toBe(100)
+    expect(foldBpm(120)).toBe(120)
+  })
+
+  it('keyLabel uses conventional spellings', () => {
+    expect(keyLabel(1, MODE_MINOR).note).toBe('Db')
+    expect(keyLabel(6, MODE_MAJOR).note).toBe('F#')
+  })
+})

--- a/frontend/src/utils/audioAnalysis.js
+++ b/frontend/src/utils/audioAnalysis.js
@@ -1,342 +1,120 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// Audio Analysis — High-precision BPM & Key detection (browser, main thread).
+// Browser client for the audio analysis engine.
 //
-// Pipeline:
-//   1. Decode + mix to mono via Web Audio API.
-//   2. Downsample to 11.025 kHz (enough for BPM/key, much faster).
-//   3. Pick a 90 s central segment (skip intro/outro).
-//   4. Single STFT pass (FFT 2048, hop 256, Hann window) that yields:
-//        · log-magnitude spectral flux  → BPM
-//        · weighted log-magnitude chromagram → key
-//   5. BPM: ACF + comb score + perceptual Rayleigh prior at 120 BPM
-//           + parabolic refinement for sub-frame precision.
-//   6. Key: Bellman-Budge profile correlation (better than Krumhansl-Schmuckler
-//           for pop/electronic). Confidence weighted by margin over runner-up.
+//   1. Decode the file with Web Audio and resample to the engine rate with a
+//      band-limited OfflineAudioContext render (proper anti-aliasing + mono).
+//   2. Run the engine in a Web Worker (UI stays responsive, progress events).
+//   3. If workers are unavailable, fall back to the same engine on the main
+//      thread — identical results, just without parallelism.
+//
+// Analysis is 100 % local: the audio never leaves the device.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const NOTES = ['C', 'C#', 'D', 'Eb', 'E', 'F', 'F#', 'G', 'Ab', 'A', 'Bb', 'B']
+import { ENGINE_SAMPLE_RATE } from './engineConfig.js'
 
-// Bellman-Budge profiles — derived from large pop/rock corpus statistics.
-// Significantly better than Krumhansl-Schmuckler for modern music.
-const PROFILE_MAJOR = [16.80, 0.86, 12.95, 1.41, 13.49, 11.93, 1.25, 20.28, 1.80, 8.04, 0.62, 10.57]
-const PROFILE_MINOR = [18.16, 0.69, 12.99, 13.34, 1.07, 11.15, 1.38, 21.07, 7.49, 1.53, 0.92, 10.21]
+// Typed engine errors that describe the *audio* (not the runtime) — they must
+// surface to the user instead of triggering the main-thread fallback.
+const AUDIO_ERRORS = new Set(['AUDIO_TOO_SHORT', 'AUDIO_SILENT'])
 
-// ─── FFT (iterative radix-2 with cached twiddle factors) ────────────────────
-const _twiddleCache = new Map()
-function getTwiddles (n) {
-  let t = _twiddleCache.get(n)
-  if (t) return t
-  const cos = new Float64Array(n >> 1)
-  const sin = new Float64Array(n >> 1)
-  for (let i = 0; i < n >> 1; i++) {
-    const a = (-2 * Math.PI * i) / n
-    cos[i] = Math.cos(a)
-    sin[i] = Math.sin(a)
+async function decodeToMono (arrayBuffer) {
+  const AC = window.AudioContext || window.webkitAudioContext
+  const probe = new AC()
+  let decoded
+  try {
+    decoded = await probe.decodeAudioData(arrayBuffer)
+  } finally {
+    probe.close().catch(() => {})
   }
-  t = { cos, sin }
-  _twiddleCache.set(n, t)
-  return t
+  const length = Math.max(1, Math.ceil(decoded.duration * ENGINE_SAMPLE_RATE))
+  const off = new OfflineAudioContext(1, length, ENGINE_SAMPLE_RATE)
+  const src = off.createBufferSource()
+  src.buffer = decoded
+  src.connect(off.destination)
+  src.start(0)
+  const rendered = await off.startRendering()
+  return { pcm: rendered.getChannelData(0), sampleRate: ENGINE_SAMPLE_RATE, duration: decoded.duration }
 }
 
-function fft (re, im) {
-  const n = re.length
-  const { cos, sin } = getTwiddles(n)
+let worker = null
+let jobSeq = 0
 
-  // Bit reversal permutation
-  let j = 0
-  for (let i = 1; i < n; i++) {
-    let bit = n >> 1
-    while (j & bit) { j ^= bit; bit >>= 1 }
-    j ^= bit
-    if (i < j) {
-      let tmp = re[i]; re[i] = re[j]; re[j] = tmp
-      tmp = im[i]; im[i] = im[j]; im[j] = tmp
-    }
+function getWorker () {
+  if (!worker) {
+    worker = new Worker(new URL('../workers/audioAnalysis.worker.js', import.meta.url), { type: 'module' })
   }
+  return worker
+}
 
-  // Butterflies
-  for (let len = 2; len <= n; len <<= 1) {
-    const half = len >> 1
-    const step = n / len
-    for (let i = 0; i < n; i += len) {
-      let kt = 0
-      for (let k = 0; k < half; k++) {
-        const c = cos[kt]
-        const s = sin[kt]
-        const tRe = c * re[i + k + half] - s * im[i + k + half]
-        const tIm = c * im[i + k + half] + s * re[i + k + half]
-        re[i + k + half] = re[i + k] - tRe
-        im[i + k + half] = im[i + k] - tIm
-        re[i + k] += tRe
-        im[i + k] += tIm
-        kt += step
+export function disposeAnalyzer () {
+  if (worker) {
+    worker.terminate()
+    worker = null
+  }
+}
+
+function analyzeInWorker (pcm, sampleRate, duration, report) {
+  return new Promise((resolve, reject) => {
+    const w = getWorker()
+    const id = ++jobSeq
+    const timeout = setTimeout(() => {
+      cleanup()
+      disposeAnalyzer()
+      reject(new Error('WORKER_TIMEOUT'))
+    }, 120000)
+
+    const onMessage = (e) => {
+      const msg = e.data
+      if (!msg || msg.id !== id) return
+      if (msg.type === 'progress') { report(msg.stage, 10 + msg.pct * 0.9); return }
+      cleanup()
+      if (msg.type === 'result') {
+        resolve(msg.result)
+      } else {
+        const err = new Error(msg.message)
+        if (AUDIO_ERRORS.has(msg.message)) err.audioError = true
+        reject(err)
       }
     }
-  }
-}
-
-// ─── Linear-interp downsampler ──────────────────────────────────────────────
-function downsample (data, srIn, srOut) {
-  if (srIn === srOut) return data
-  const ratio = srIn / srOut
-  const outLen = Math.floor(data.length / ratio)
-  const out = new Float32Array(outLen)
-  for (let i = 0; i < outLen; i++) {
-    const idx = i * ratio
-    const i0 = Math.floor(idx)
-    const i1 = Math.min(i0 + 1, data.length - 1)
-    const t = idx - i0
-    out[i] = data[i0] * (1 - t) + data[i1] * t
-  }
-  return out
-}
-
-// ─── Pearson correlation ────────────────────────────────────────────────────
-function pearson (a, b) {
-  const n = a.length
-  let sA = 0, sB = 0
-  for (let i = 0; i < n; i++) { sA += a[i]; sB += b[i] }
-  const mA = sA / n, mB = sB / n
-  let num = 0, dA = 0, dB = 0
-  for (let i = 0; i < n; i++) {
-    const da = a[i] - mA, db = b[i] - mB
-    num += da * db; dA += da * da; dB += db * db
-  }
-  return num / (Math.sqrt(dA * dB) || 1)
-}
-
-// ─── Single STFT pass → onset envelope + chromagram ─────────────────────────
-function analyzeSTFT (data, sampleRate, fftSize, hop) {
-  const n = data.length
-  const half = fftSize >> 1
-  const nFrames = Math.max(0, Math.floor((n - fftSize) / hop) + 1)
-
-  // Hann window
-  const win = new Float32Array(fftSize)
-  for (let i = 0; i < fftSize; i++) {
-    win[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (fftSize - 1)))
-  }
-
-  // Pre-compute per-bin pitch class + perceptual weighting
-  // Bass (55-250 Hz): boost — key root usually lives here
-  // Mids (250-2000 Hz): nominal
-  // Highs (>2000 Hz): attenuate — cymbals/noise
-  const binPC = new Int8Array(half)
-  const binWeight = new Float32Array(half)
-  for (let k = 1; k < half; k++) {
-    const freq = (k * sampleRate) / fftSize
-    if (freq < 55 || freq > 4500) { binPC[k] = -1; continue }
-    const midi = 12 * Math.log2(freq / 440) + 69
-    binPC[k] = ((Math.round(midi) % 12) + 12) % 12
-    binWeight[k] = freq < 250 ? 1.4
-                 : freq < 1000 ? 1.0
-                 : freq < 2000 ? 0.7
-                 : 0.4
-  }
-
-  const re = new Float64Array(fftSize)
-  const im = new Float64Array(fftSize)
-  const prevLog = new Float32Array(half)
-  const onset = new Float32Array(nFrames)
-  const chroma = new Float64Array(12)
-  let firstFrame = true
-
-  for (let f = 0; f < nFrames; f++) {
-    const off = f * hop
-    for (let i = 0; i < fftSize; i++) { re[i] = data[off + i] * win[i]; im[i] = 0 }
-    fft(re, im)
-
-    let flux = 0
-    for (let k = 1; k < half; k++) {
-      const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k])
-      const lm = Math.log(1 + mag)
-
-      // Half-wave-rectified log-magnitude spectral flux
-      if (!firstFrame) {
-        const d = lm - prevLog[k]
-        if (d > 0) flux += d
-      }
-      prevLog[k] = lm
-
-      // Chroma accumulation (log-compressed + perceptually weighted)
-      const pc = binPC[k]
-      if (pc >= 0) chroma[pc] += lm * binWeight[k]
+    const onError = () => {
+      cleanup()
+      disposeAnalyzer()
+      reject(new Error('WORKER_FAILED'))
+    }
+    function cleanup () {
+      clearTimeout(timeout)
+      w.removeEventListener('message', onMessage)
+      w.removeEventListener('error', onError)
     }
 
-    onset[f] = flux
-    firstFrame = false
-  }
-
-  // Normalize chroma to [0, 1]
-  let cmax = 0
-  for (let i = 0; i < 12; i++) if (chroma[i] > cmax) cmax = chroma[i]
-  if (cmax > 0) for (let i = 0; i < 12; i++) chroma[i] /= cmax
-
-  return { onset, chroma }
+    w.addEventListener('message', onMessage)
+    w.addEventListener('error', onError)
+    // Transfer the PCM buffer — zero-copy handoff to the worker.
+    w.postMessage({ id, pcm, sampleRate, duration }, [pcm.buffer])
+  })
 }
 
-// ─── Tempo estimation ───────────────────────────────────────────────────────
-function estimateTempo (onset, hopSec) {
-  const n = onset.length
-  if (n < 200) return { bpm: 0, confidence: 0 }
-
-  // Adaptive high-pass: subtract local mean to remove slow trends
-  const wMean = 40
-  const x = new Float32Array(n)
-  for (let i = 0; i < n; i++) {
-    let s = 0, c = 0
-    const lo = Math.max(0, i - wMean)
-    const hi = Math.min(n - 1, i + wMean)
-    for (let k = lo; k <= hi; k++) { s += onset[k]; c++ }
-    x[i] = Math.max(0, onset[i] - s / c)
+// Main API. `onProgress` receives { stage: 'decode'|'bpm'|'key'|'done', pct }.
+export async function analyzeAudioFile (file, { onProgress } = {}) {
+  const report = (stage, pct) => {
+    if (onProgress) onProgress({ stage, pct: Math.min(100, Math.round(pct)) })
   }
 
-  // Signal energy (for normalization)
-  let r0 = 0
-  for (let i = 0; i < n; i++) r0 += x[i] * x[i]
-  if (r0 < 1e-9) return { bpm: 0, confidence: 0 }
+  report('decode', 2)
+  const { pcm, sampleRate, duration } = await decodeToMono(await file.arrayBuffer())
+  report('decode', 10)
 
-  // BPM range we search
-  const minBPM = 55
-  const maxBPM = 215
-  const minLag = Math.max(1, Math.floor(60 / maxBPM / hopSec))
-  const maxLag = Math.min(n - 1, Math.floor(60 / minBPM / hopSec))
-
-  // Autocorrelation
-  const acf = new Float32Array(maxLag + 1)
-  for (let lag = minLag; lag <= maxLag; lag++) {
-    let s = 0
-    const upper = n - lag
-    for (let i = 0; i < upper; i++) s += x[i] * x[i + lag]
-    acf[lag] = s / r0
-  }
-
-  // Final score: comb (acf at lag, 2·lag, 3·lag, 4·lag) × Rayleigh tempo prior.
-  // Comb rewards true beat structure. Prior breaks octave ambiguity in favor
-  // of perceptually-natural tempos around 120 BPM (sigma 45 BPM).
-  const score = new Float32Array(maxLag + 1)
-  for (let lag = minLag; lag <= maxLag; lag++) {
-    const bpm = 60 / (lag * hopSec)
-
-    let comb = acf[lag]
-    let totalW = 1
-    for (let m = 2; m <= 4; m++) {
-      const ml = m * lag
-      if (ml > maxLag) break
-      const w = 1 / m
-      comb += acf[ml] * w
-      totalW += w
-    }
-    comb /= totalW
-
-    const prior = Math.exp(-((bpm - 120) ** 2) / (2 * 45 * 45))
-    score[lag] = Math.max(0, comb) * (0.35 + 0.65 * prior)
-  }
-
-  // Pick best integer lag
-  let bestLag = minLag
-  for (let lag = minLag + 1; lag <= maxLag; lag++) {
-    if (score[lag] > score[bestLag]) bestLag = lag
-  }
-
-  // Parabolic interpolation around the peak → sub-frame BPM precision
-  let refined = bestLag
-  if (bestLag > minLag && bestLag < maxLag) {
-    const y1 = score[bestLag - 1]
-    const y2 = score[bestLag]
-    const y3 = score[bestLag + 1]
-    const denom = y1 - 2 * y2 + y3
-    if (Math.abs(denom) > 1e-9) {
-      const off = (y1 - y3) / (2 * denom)
-      if (Math.abs(off) < 1) refined = bestLag + off
-    }
-  }
-
-  const bpm = Math.round(60 / (refined * hopSec))
-  const confidence = Math.round(Math.max(0, Math.min(100, score[bestLag] * 110)))
-  return { bpm, confidence }
-}
-
-// ─── Key estimation ─────────────────────────────────────────────────────────
-function estimateKey (chroma) {
-  let best = -Infinity
-  let second = -Infinity
-  let root = 0
-  let mode = 'mayor'
-  const rot = new Array(12)
-
-  for (let r = 0; r < 12; r++) {
-    for (let i = 0; i < 12; i++) rot[i] = chroma[(i + r) % 12]
-    const maj = pearson(rot, PROFILE_MAJOR)
-    const min = pearson(rot, PROFILE_MINOR)
-
-    if (maj > best) { second = best; best = maj; root = r; mode = 'mayor' }
-    else if (maj > second) second = maj
-
-    if (min > best) { second = best; best = min; root = r; mode = 'menor' }
-    else if (min > second) second = min
-  }
-
-  // Confidence = correlation strength + margin over runner-up
-  const baseConf = ((best + 1) / 2) * 80
-  const marginBoost = Math.max(0, best - second) * 120
-  const confidence = Math.round(Math.min(100, Math.max(0, baseConf + marginBoost)))
-
-  return { note: NOTES[root], mode, confidence }
-}
-
-// ─── Public API ─────────────────────────────────────────────────────────────
-export async function analyzeAudio (arrayBuffer) {
-  const ctx = new AudioContext()
-  const buffer = await ctx.decodeAudioData(arrayBuffer)
-  ctx.close()
-
-  // Mix to mono
-  const nc = buffer.numberOfChannels
-  const len = buffer.length
-  const srOriginal = buffer.sampleRate
-  const monoOrig = new Float32Array(len)
-  for (let c = 0; c < nc; c++) {
-    const ch = buffer.getChannelData(c)
-    for (let i = 0; i < len; i++) monoOrig[i] += ch[i] / nc
-  }
-
-  // Resample → 11.025 kHz (Nyquist 5.5 kHz covers all relevant musical content)
-  const TARGET_SR = 11025
-  const mono = downsample(monoOrig, srOriginal, TARGET_SR)
-
-  // Pick analysis window: middle of the track, up to 90 s
-  const totalDur = buffer.duration
-  let startSec, endSec
-  if (totalDur > 90) {
-    startSec = Math.max(5, totalDur * 0.15)
-    endSec = Math.min(startSec + 90, totalDur * 0.85)
-  } else if (totalDur > 30) {
-    startSec = Math.min(2, totalDur * 0.1)
-    endSec = totalDur - Math.min(2, totalDur * 0.05)
-  } else {
-    startSec = 0
-    endSec = totalDur
-  }
-  const startIdx = Math.floor(startSec * TARGET_SR)
-  const endIdx = Math.min(mono.length, Math.floor(endSec * TARGET_SR))
-  const segment = mono.subarray(startIdx, endIdx)
-
-  // STFT — 2048-point FFT, 256-sample hop (87.5% overlap, ~23 ms time resolution)
-  const FFT_SIZE = 2048
-  const HOP = 256
-  const hopSec = HOP / TARGET_SR
-  const { onset, chroma } = analyzeSTFT(segment, TARGET_SR, FFT_SIZE, HOP)
-
-  const tempo = estimateTempo(onset, hopSec)
-  const key = estimateKey(chroma)
-
-  return {
-    bpm:           tempo.bpm,
-    bpmConfidence: tempo.confidence,
-    key:           key.note,
-    mode:          key.mode,
-    keyConfidence: key.confidence,
-    duration:      buffer.duration,
+  try {
+    return await analyzeInWorker(pcm, sampleRate, duration, report)
+  } catch (err) {
+    if (err.audioError) throw err
+    // Worker unavailable or crashed → same engine on the main thread.
+    // The PCM buffer was transferred away, so decode again.
+    const again = await decodeToMono(await file.arrayBuffer())
+    await new Promise(r => setTimeout(r, 30)) // let the progress UI paint
+    const { analyzeAudioData } = await import('./audioEngine.js')
+    return analyzeAudioData(again.pcm, again.sampleRate, {
+      duration: again.duration,
+      onProgress: ({ stage, pct }) => report(stage, 10 + pct * 0.9),
+    })
   }
 }

--- a/frontend/src/utils/audioEngine.js
+++ b/frontend/src/utils/audioEngine.js
@@ -1,0 +1,60 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Audio analysis orchestrator — pure function over mono PCM.
+// Runs identically in a Web Worker, on the main thread, or in Node (used by
+// the ground-truth validation suite in scripts/validate-audio-engine.mjs).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { estimateTempo } from './tempoEngine.js'
+import { estimateKey } from './keyEngine.js'
+import { snapBpm } from './musicTheory.js'
+
+export { ENGINE_SAMPLE_RATE } from './engineConfig.js'
+
+export function analyzeAudioData (pcm, sampleRate, { duration, onProgress } = {}) {
+  const report = (stage, pct) => {
+    if (onProgress) onProgress({ stage, pct: Math.min(100, Math.round(pct)) })
+  }
+
+  if (!pcm || pcm.length < sampleRate * 3) {
+    throw new Error('AUDIO_TOO_SHORT')
+  }
+
+  let rms = 0
+  for (let i = 0; i < pcm.length; i += 16) rms += pcm[i] * pcm[i]
+  rms = Math.sqrt(rms / Math.ceil(pcm.length / 16))
+  if (rms < 1e-5) {
+    throw new Error('AUDIO_SILENT')
+  }
+
+  report('bpm', 2)
+  const tempo = estimateTempo(pcm, sampleRate, {
+    onProgress: (p) => report('bpm', 2 + p * 53),
+  })
+
+  report('key', 55)
+  const key = estimateKey(pcm, sampleRate, {
+    onProgress: (p) => report('key', 55 + p * 43),
+  })
+
+  const snapped = snapBpm(tempo.bpm)
+  const altSnapped = tempo.alt ? snapBpm(tempo.alt) : null
+  report('done', 100)
+
+  return {
+    bpm: snapped.value,
+    bpmDisplay: snapped.display,
+    bpmConfidence: tempo.confidence,
+    bpmAlt: altSnapped ? altSnapped.value : null,
+    bpmAltDisplay: altSnapped ? altSnapped.display : null,
+    key: key.note,
+    mode: key.mode,
+    camelot: key.camelot,
+    openKey: key.openKey,
+    keyConfidence: key.confidence,
+    keyAlternative: key.alternative,
+    tuningHz: key.tuningHz,
+    tuningCents: key.tuningCents,
+    duration: duration ?? pcm.length / sampleRate,
+    metrics: { tempo: tempo.metrics, key: key.details ?? null },
+  }
+}

--- a/frontend/src/utils/dsp.js
+++ b/frontend/src/utils/dsp.js
@@ -1,0 +1,180 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// DSP primitives shared by the tempo and key engines.
+// Pure numeric code — safe to run on the main thread, a worker or Node.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─── FFT (iterative radix-2, cached twiddle factors) ────────────────────────
+const _twiddleCache = new Map()
+function getTwiddles (n) {
+  let t = _twiddleCache.get(n)
+  if (t) return t
+  const cos = new Float64Array(n >> 1)
+  const sin = new Float64Array(n >> 1)
+  for (let i = 0; i < n >> 1; i++) {
+    const a = (-2 * Math.PI * i) / n
+    cos[i] = Math.cos(a)
+    sin[i] = Math.sin(a)
+  }
+  t = { cos, sin }
+  _twiddleCache.set(n, t)
+  return t
+}
+
+export function fft (re, im) {
+  const n = re.length
+  const { cos, sin } = getTwiddles(n)
+
+  let j = 0
+  for (let i = 1; i < n; i++) {
+    let bit = n >> 1
+    while (j & bit) { j ^= bit; bit >>= 1 }
+    j ^= bit
+    if (i < j) {
+      let tmp = re[i]; re[i] = re[j]; re[j] = tmp
+      tmp = im[i]; im[i] = im[j]; im[j] = tmp
+    }
+  }
+
+  for (let len = 2; len <= n; len <<= 1) {
+    const half = len >> 1
+    const step = n / len
+    for (let i = 0; i < n; i += len) {
+      let kt = 0
+      for (let k = 0; k < half; k++) {
+        const c = cos[kt]
+        const s = sin[kt]
+        const tRe = c * re[i + k + half] - s * im[i + k + half]
+        const tIm = c * im[i + k + half] + s * re[i + k + half]
+        re[i + k + half] = re[i + k] - tRe
+        im[i + k + half] = im[i + k] - tIm
+        re[i + k] += tRe
+        im[i + k] += tIm
+        kt += step
+      }
+    }
+  }
+}
+
+export function nextPow2 (n) {
+  let p = 1
+  while (p < n) p <<= 1
+  return p
+}
+
+export function hannWindow (n) {
+  const w = new Float32Array(n)
+  for (let i = 0; i < n; i++) w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (n - 1)))
+  return w
+}
+
+// Autocorrelation via FFT with magnitude compression (generalized ACF,
+// Tolonen & Karjalainen). exponent 2 = classic ACF; ~1 flattens dynamics and
+// is far more robust for onset envelopes. Input is zero-padded ×2 to avoid
+// circular wrap-around.
+export function generalizedACF (x, exponent = 1) {
+  const n = x.length
+  const size = nextPow2(2 * n)
+  const re = new Float64Array(size)
+  const im = new Float64Array(size)
+  re.set(x)
+  fft(re, im)
+  for (let i = 0; i < size; i++) {
+    const mag = Math.sqrt(re[i] * re[i] + im[i] * im[i])
+    re[i] = Math.pow(mag, exponent)
+    im[i] = 0
+  }
+  // The compressed spectrum is real and even-symmetric, so its inverse DFT
+  // equals its forward DFT divided by N.
+  fft(re, im)
+  const acf = new Float64Array(n)
+  const norm = re[0] || 1
+  for (let i = 0; i < n; i++) acf[i] = re[i] / norm
+  return acf
+}
+
+// Windowed-sinc FIR low-pass (Hamming), zero-phase via symmetric kernel.
+export function lowpassFIR (x, cutoffNorm, taps = 21) {
+  const half = (taps - 1) / 2
+  const kernel = new Float64Array(taps)
+  let sum = 0
+  for (let i = 0; i < taps; i++) {
+    const m = i - half
+    const sinc = m === 0 ? 2 * cutoffNorm : Math.sin(2 * Math.PI * cutoffNorm * m) / (Math.PI * m)
+    const hamming = 0.54 - 0.46 * Math.cos((2 * Math.PI * i) / (taps - 1))
+    kernel[i] = sinc * hamming
+    sum += kernel[i]
+  }
+  for (let i = 0; i < taps; i++) kernel[i] /= sum
+
+  const n = x.length
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) {
+    let acc = 0
+    for (let k = 0; k < taps; k++) {
+      let idx = i + k - half
+      if (idx < 0) idx = 0
+      else if (idx >= n) idx = n - 1
+      acc += x[idx] * kernel[k]
+    }
+    out[i] = acc
+  }
+  return out
+}
+
+// Sliding mean via prefix sums (O(n)).
+export function movingMean (x, halfWin) {
+  const n = x.length
+  const prefix = new Float64Array(n + 1)
+  for (let i = 0; i < n; i++) prefix[i + 1] = prefix[i] + x[i]
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) {
+    const lo = Math.max(0, i - halfWin)
+    const hi = Math.min(n - 1, i + halfWin)
+    out[i] = (prefix[hi + 1] - prefix[lo]) / (hi - lo + 1)
+  }
+  return out
+}
+
+// Parabolic interpolation around a discrete peak → fractional position/value.
+export function parabolicPeak (y, i) {
+  if (i <= 0 || i >= y.length - 1) return { pos: i, val: y[i] }
+  const y1 = y[i - 1]
+  const y2 = y[i]
+  const y3 = y[i + 1]
+  const denom = y1 - 2 * y2 + y3
+  if (Math.abs(denom) < 1e-12) return { pos: i, val: y2 }
+  const off = 0.5 * (y1 - y3) / denom
+  if (Math.abs(off) > 1) return { pos: i, val: y2 }
+  return { pos: i + off, val: y2 - 0.25 * (y1 - y3) * off }
+}
+
+// Linear-interpolated read of a sampled signal at a fractional index.
+export function sampleAt (x, pos) {
+  if (pos <= 0) return x[0]
+  const n = x.length
+  if (pos >= n - 1) return x[n - 1]
+  const i0 = Math.floor(pos)
+  const t = pos - i0
+  return x[i0] * (1 - t) + x[i0 + 1] * t
+}
+
+export function pearson (a, b) {
+  const n = a.length
+  let sA = 0
+  let sB = 0
+  for (let i = 0; i < n; i++) { sA += a[i]; sB += b[i] }
+  const mA = sA / n
+  const mB = sB / n
+  let num = 0
+  let dA = 0
+  let dB = 0
+  for (let i = 0; i < n; i++) {
+    const da = a[i] - mA
+    const db = b[i] - mB
+    num += da * db
+    dA += da * da
+    dB += db * db
+  }
+  const den = Math.sqrt(dA * dB)
+  return den > 0 ? num / den : 0
+}

--- a/frontend/src/utils/engineConfig.js
+++ b/frontend/src/utils/engineConfig.js
@@ -1,0 +1,4 @@
+// The analysis engines are tuned for this rate; the browser client resamples
+// decoded audio to it. Kept in its own module so the lightweight client can
+// import it without pulling the DSP code into the main bundle.
+export const ENGINE_SAMPLE_RATE = 22050

--- a/frontend/src/utils/keyEngine.js
+++ b/frontend/src/utils/keyEngine.js
@@ -1,0 +1,356 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Key engine — professional-grade musical key estimation.
+//
+// Method:
+//   1. STFT with long frames (≈370 ms) → spectral peaks with quadratic
+//      interpolation (sub-bin frequency precision).
+//   2. Tuning-frequency estimation from the peak deviation histogram —
+//      tracks not tuned to A=440 no longer smear across pitch classes.
+//   3. HPCP (Harmonic Pitch Class Profile, Gómez 2006): 36-bin resolution,
+//      harmonic summation (peaks vote for their possible fundamentals),
+//      cos² spreading, per-frame unit-max normalization, silence gating.
+//   4. Template matching against four published key profiles —
+//      Krumhansl-Kessler, Temperley, EDMA and bgate (Faraldo, Beatport
+//      corpus — strongest on electronic music) — ensemble-weighted.
+//   5. Temporal voting over ~20 s chunks + full-track profile: a key must
+//      win both globally and consistently over time to score high confidence.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { fft, hannWindow, pearson } from './dsp.js'
+import { keyLabel, toCamelot, toOpenKey, keyRelationship, MODE_MAJOR, MODE_MINOR } from './musicTheory.js'
+
+// Published key profiles (index 0 = tonic). Sources: Krumhansl & Kessler 1982;
+// Temperley (Kostka-Payne); Faraldo et al. — EDMA and bgate (Beatport corpus).
+export const KEY_PROFILES = [
+  {
+    name: 'krumhansl',
+    weight: 0.85,
+    major: [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88],
+    minor: [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17],
+  },
+  {
+    name: 'temperley',
+    weight: 1.0,
+    major: [5.0, 2.0, 3.5, 2.0, 4.5, 4.0, 2.0, 4.5, 2.0, 3.5, 1.5, 4.0],
+    minor: [5.0, 2.0, 3.5, 4.5, 2.0, 4.0, 2.0, 4.5, 3.5, 2.0, 1.5, 4.0],
+  },
+  {
+    name: 'edma',
+    weight: 1.1,
+    major: [1.00, 0.29, 0.50, 0.40, 0.60, 0.56, 0.32, 0.80, 0.31, 0.45, 0.42, 0.39],
+    minor: [1.00, 0.31, 0.44, 0.58, 0.33, 0.49, 0.29, 0.78, 0.43, 0.29, 0.53, 0.32],
+  },
+  {
+    name: 'bgate',
+    weight: 1.15,
+    major: [1.00, 0.00, 0.42, 0.00, 0.53, 0.37, 0.00, 0.77, 0.00, 0.38, 0.21, 0.30],
+    minor: [1.00, 0.00, 0.36, 0.39, 0.00, 0.38, 0.00, 0.74, 0.27, 0.00, 0.42, 0.23],
+  },
+]
+
+const MIN_FREQ = 55
+const MAX_FREQ = 5000
+const MAX_PEAKS = 40
+const HPCP_BINS = 36
+const HARMONIC_WEIGHTS = [1.0, 0.8, 0.64, 0.512] // peak votes for f, f/2, f/3, f/4
+
+// ─── Spectral peak extraction (quadratic interpolation on log magnitude) ────
+function framePeaks (mag, sr, fftSize, out) {
+  const binHz = sr / fftSize
+  const loBin = Math.max(2, Math.ceil(MIN_FREQ / binHz))
+  const hiBin = Math.min(mag.length - 2, Math.floor(MAX_FREQ / binHz))
+
+  let frameMax = 0
+  for (let k = loBin; k <= hiBin; k++) if (mag[k] > frameMax) frameMax = mag[k]
+  if (frameMax <= 1e-9) return 0
+  const thresh = Math.max(frameMax * 1e-3, 1e-8) // −60 dB relative floor
+
+  let count = 0
+  for (let k = loBin; k <= hiBin && count < MAX_PEAKS * 3; k++) {
+    const m = mag[k]
+    if (m < thresh || m <= mag[k - 1] || m < mag[k + 1]) continue
+    // Quadratic interpolation on log-magnitude → sub-bin frequency.
+    const a = Math.log(mag[k - 1] + 1e-12)
+    const b = Math.log(m + 1e-12)
+    const c = Math.log(mag[k + 1] + 1e-12)
+    const denom = a - 2 * b + c
+    const off = Math.abs(denom) > 1e-12 ? Math.min(0.5, Math.max(-0.5, 0.5 * (a - c) / denom)) : 0
+    out.push({ freq: (k + off) * binHz, power: m * m })
+    count++
+  }
+
+  if (count > MAX_PEAKS) {
+    out.sort((p, q) => q.power - p.power)
+    out.length = MAX_PEAKS
+  }
+  let power = 0
+  for (const p of out) power += p.power
+  return power
+}
+
+// ─── Tuning estimation: histogram of peak deviations from the 440 grid ──────
+function estimateTuningCents (histogram) {
+  const n = histogram.length // 100 bins → 1 cent each, index 0 = −50 cents
+  let total = 0
+  let max = 0
+  for (let i = 0; i < n; i++) { total += histogram[i]; if (histogram[i] > max) max = histogram[i] }
+  if (total <= 0 || max < (total / n) * 1.8) return 0 // flat histogram → keep 440
+
+  // Circular smoothing then parabolic peak.
+  const smooth = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    for (let d = -2; d <= 2; d++) smooth[i] += histogram[(i + d + n) % n] * (3 - Math.abs(d))
+  }
+  let peak = 0
+  for (let i = 1; i < n; i++) if (smooth[i] > smooth[peak]) peak = i
+  const prev = smooth[(peak - 1 + n) % n]
+  const next = smooth[(peak + 1) % n]
+  const denom = prev - 2 * smooth[peak] + next
+  const off = Math.abs(denom) > 1e-12 ? Math.min(0.5, Math.max(-0.5, 0.5 * (prev - next) / denom)) : 0
+  let cents = (peak + off) - 50
+  if (cents >= 50) cents -= 100
+  return cents
+}
+
+// ─── HPCP accumulation for one frame ─────────────────────────────────────────
+function accumulateHPCP (peaks, tuningRef, hpcp) {
+  hpcp.fill(0)
+  for (const { freq, power } of peaks) {
+    for (let h = 0; h < HARMONIC_WEIGHTS.length; h++) {
+      const f0 = freq / (h + 1)
+      if (f0 < MIN_FREQ * 0.9) break
+      const pcFrac = ((12 * Math.log2(f0 / tuningRef) + 69) % 12 + 12) % 12
+      const center = pcFrac * (HPCP_BINS / 12)
+      // cos² spreading over ±1.5 bins (±½ semitone)
+      const lo = Math.ceil(center - 1.5)
+      for (let b = lo; b <= center + 1.5; b++) {
+        const d = (b - center) / 1.5
+        const w = Math.cos((Math.PI / 2) * d)
+        hpcp[((b % HPCP_BINS) + HPCP_BINS) % HPCP_BINS] += power * HARMONIC_WEIGHTS[h] * w * w
+      }
+    }
+  }
+}
+
+function foldTo12 (h36) {
+  const pc = new Float64Array(12)
+  for (let p = 0; p < 12; p++) {
+    const c = 3 * p
+    pc[p] = 0.5 * h36[(c - 1 + HPCP_BINS) % HPCP_BINS] + h36[c] + 0.5 * h36[(c + 1) % HPCP_BINS]
+  }
+  return pc
+}
+
+// Ensemble profile match: summed weighted Pearson over all profiles.
+// Returns scores for all 24 keys (index = root + (mode === minor ? 12 : 0)).
+function ensembleScores (chroma12) {
+  const scores = new Float64Array(24)
+  const rotated = new Array(12)
+  for (let root = 0; root < 12; root++) {
+    for (let i = 0; i < 12; i++) rotated[i] = chroma12[(i + root) % 12]
+    for (const prof of KEY_PROFILES) {
+      scores[root] += prof.weight * pearson(rotated, prof.major)
+      scores[root + 12] += prof.weight * pearson(rotated, prof.minor)
+    }
+  }
+  const totalW = KEY_PROFILES.reduce((s, p) => s + p.weight, 0)
+  for (let i = 0; i < 24; i++) scores[i] /= totalW
+  return scores
+}
+
+function argmax24 (scores, skip = -1) {
+  let best = -1
+  for (let i = 0; i < 24; i++) {
+    if (i === skip) continue
+    if (best < 0 || scores[i] > scores[best]) best = i
+  }
+  return best
+}
+
+const idxToKey = (i) => ({ pitchClass: i % 12, mode: i < 12 ? MODE_MAJOR : MODE_MINOR })
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+export function estimateKey (pcm, sr, { onProgress } = {}) {
+  const report = (p) => { if (onProgress) onProgress(p) }
+
+  // Central window, up to 4 minutes — enough harmonic evidence for any track.
+  const maxSamples = Math.floor(240 * sr)
+  let segment = pcm
+  if (pcm.length > maxSamples) {
+    const start = Math.floor((pcm.length - maxSamples) / 2)
+    segment = pcm.subarray(start, start + maxSamples)
+  }
+
+  let fftSize = 1
+  while (fftSize < sr * 0.34) fftSize <<= 1 // 8192 @ 22 050 Hz → 2.7 Hz/bin
+  const hop = fftSize >> 1
+  const nFrames = Math.max(0, Math.floor((segment.length - fftSize) / hop) + 1)
+
+  const empty = {
+    pitchClass: -1, mode: MODE_MINOR, note: '—', camelot: null, openKey: null,
+    confidence: 0, tuningHz: 440, tuningCents: 0, alternative: null, chroma: null,
+  }
+  if (nFrames < 4) return empty
+
+  const win = hannWindow(fftSize)
+  const re = new Float64Array(fftSize)
+  const im = new Float64Array(fftSize)
+  const mag = new Float64Array(fftSize >> 1)
+
+  // Pass 1 — spectral peaks per frame + global tuning histogram.
+  const allPeaks = new Array(nFrames)
+  const framePower = new Float64Array(nFrames)
+  const tuningHist = new Float64Array(100)
+  for (let f = 0; f < nFrames; f++) {
+    const off = f * hop
+    for (let i = 0; i < fftSize; i++) { re[i] = segment[off + i] * win[i]; im[i] = 0 }
+    fft(re, im)
+    for (let k = 0; k < mag.length; k++) mag[k] = Math.sqrt(re[k] * re[k] + im[k] * im[k])
+
+    const peaks = []
+    framePower[f] = framePeaks(mag, sr, fftSize, peaks)
+    allPeaks[f] = peaks
+
+    for (const { freq, power } of peaks) {
+      if (freq < 110 || freq > 3520) continue
+      const cents = 1200 * Math.log2(freq / 440)
+      const dev = ((cents % 100) + 150) % 100 // 0..100, 50 = in tune
+      tuningHist[Math.min(99, Math.max(0, Math.round(dev)))] += Math.sqrt(power)
+    }
+    if ((f & 63) === 0) report(0.05 + 0.55 * (f / nFrames))
+  }
+
+  const tuningCents = estimateTuningCents(tuningHist)
+  const tuningRef = 440 * Math.pow(2, tuningCents / 1200)
+  report(0.65)
+
+  // Silence gate: drop frames far below the median harmonic power.
+  const powers = Array.from(framePower).filter(p => p > 0).sort((a, b) => a - b)
+  if (powers.length < 4) return empty
+  const medianPower = powers[Math.floor(powers.length / 2)]
+  const gate = medianPower * 0.02
+
+  // Pass 2 — HPCP per frame → full-track average + ~20 s chunk averages.
+  const CHUNK_SEC = 20
+  const framesPerChunk = Math.max(1, Math.round((CHUNK_SEC * sr) / hop))
+  const nChunks = Math.ceil(nFrames / framesPerChunk)
+  const hpcpFrame = new Float64Array(HPCP_BINS)
+  const hpcpFull = new Float64Array(HPCP_BINS)
+  const hpcpChunks = Array.from({ length: nChunks }, () => new Float64Array(HPCP_BINS))
+  const chunkFrames = new Int32Array(nChunks)
+  let keptFrames = 0
+
+  for (let f = 0; f < nFrames; f++) {
+    if (framePower[f] < gate || allPeaks[f].length === 0) continue
+    accumulateHPCP(allPeaks[f], tuningRef, hpcpFrame)
+    let fMax = 0
+    for (let i = 0; i < HPCP_BINS; i++) if (hpcpFrame[i] > fMax) fMax = hpcpFrame[i]
+    if (fMax <= 0) continue
+    const chunk = Math.min(nChunks - 1, Math.floor(f / framesPerChunk))
+    for (let i = 0; i < HPCP_BINS; i++) {
+      const v = hpcpFrame[i] / fMax
+      hpcpFull[i] += v
+      hpcpChunks[chunk][i] += v
+    }
+    chunkFrames[chunk]++
+    keptFrames++
+  }
+  if (keptFrames < 4) return empty
+  report(0.8)
+
+  // Global candidate scores.
+  const chroma12 = foldTo12(hpcpFull)
+  const globalScores = ensembleScores(chroma12)
+
+  // Temporal voting: each usable chunk votes for its own best key,
+  // weighted by how decisive that chunk was.
+  const chunkVotes = new Float64Array(24)
+  let chunkTotal = 0
+  let usedChunks = 0
+  for (let c = 0; c < nChunks; c++) {
+    if (chunkFrames[c] < framesPerChunk * 0.15) continue
+    const scores = ensembleScores(foldTo12(hpcpChunks[c]))
+    const best = argmax24(scores)
+    const second = argmax24(scores, best)
+    const margin = Math.max(0, scores[best] - scores[second])
+    const w = Math.max(0, scores[best]) * (0.4 + 0.6 * Math.min(1, margin * 8))
+    chunkVotes[best] += w
+    chunkTotal += w
+    usedChunks++
+  }
+  report(0.92)
+
+  // Combine global fit with temporal consistency.
+  let gMin = Infinity
+  let gMax = -Infinity
+  for (let i = 0; i < 24; i++) {
+    if (globalScores[i] < gMin) gMin = globalScores[i]
+    if (globalScores[i] > gMax) gMax = globalScores[i]
+  }
+  const gSpan = gMax - gMin || 1
+  const finalScores = new Float64Array(24)
+  for (let i = 0; i < 24; i++) {
+    const globalN = (globalScores[i] - gMin) / gSpan
+    const voteShare = chunkTotal > 0 ? chunkVotes[i] / chunkTotal : 0
+    finalScores[i] = 0.55 * globalN + 0.45 * voteShare
+  }
+
+  const bestIdx = argmax24(finalScores)
+  const secondIdx = argmax24(finalScores, bestIdx)
+  const winner = idxToKey(bestIdx)
+  const second = idxToKey(secondIdx)
+
+  // Confidence: absolute profile fit, margin over the runner-up, temporal
+  // agreement, and cross-profile unanimity.
+  const winnerCorr = globalScores[bestIdx] // weighted mean Pearson, ≲ 0.95
+  const margin = finalScores[bestIdx] - finalScores[secondIdx]
+  const voteShareWinner = chunkTotal > 0 ? chunkVotes[bestIdx] / chunkTotal : 0
+  let profileAgree = 0
+  for (const prof of KEY_PROFILES) {
+    const own = ensembleScoresSingle(chroma12, prof)
+    if (argmax24(own) === bestIdx) profileAgree++
+  }
+  const corrN = Math.min(1, Math.max(0, (winnerCorr - 0.1) / 0.75))
+  const confidence = Math.round(Math.min(98, Math.max(5, 100 * (
+    0.34 * corrN +
+    0.27 * voteShareWinner +
+    0.21 * (profileAgree / KEY_PROFILES.length) +
+    0.18 * Math.min(1, margin * 5)
+  ))))
+
+  const showAlt = margin < 0.18
+  const relationship = keyRelationship(winner, second)
+
+  const { note, mode } = keyLabel(winner.pitchClass, winner.mode)
+  return {
+    pitchClass: winner.pitchClass,
+    mode,
+    note,
+    camelot: toCamelot(winner.pitchClass, winner.mode),
+    openKey: toOpenKey(winner.pitchClass, winner.mode),
+    confidence,
+    tuningHz: Math.round(tuningRef * 10) / 10,
+    tuningCents: Math.round(tuningCents),
+    alternative: showAlt
+      ? {
+          ...keyLabel(second.pitchClass, second.mode),
+          pitchClass: second.pitchClass,
+          camelot: toCamelot(second.pitchClass, second.mode),
+          relationship,
+        }
+      : null,
+    chroma: Array.from(chroma12),
+    details: { usedChunks, keptFrames, profileAgree },
+  }
+}
+
+function ensembleScoresSingle (chroma12, prof) {
+  const scores = new Float64Array(24)
+  const rotated = new Array(12)
+  for (let root = 0; root < 12; root++) {
+    for (let i = 0; i < 12; i++) rotated[i] = chroma12[(i + root) % 12]
+    scores[root] = pearson(rotated, prof.major)
+    scores[root + 12] = pearson(rotated, prof.minor)
+  }
+  return scores
+}

--- a/frontend/src/utils/musicTheory.js
+++ b/frontend/src/utils/musicTheory.js
@@ -1,0 +1,87 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Music theory helpers — note naming, Camelot wheel, BPM display rules.
+// Pure functions, no DOM/audio dependencies (unit-testable in Node/Jest).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Display spelling favours the conventional DJ/producer names (flats where
+// customary). Index = pitch class, 0 = C.
+export const NOTE_NAMES = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'F#', 'G', 'Ab', 'A', 'Bb', 'B']
+
+export const MODE_MAJOR = 'major'
+export const MODE_MINOR = 'minor'
+
+// Camelot wheel — the de-facto DJ standard for harmonic mixing.
+// 8B = C major, 8A = A minor; +7 semitones (a fifth) = +1 on the wheel.
+const CAMELOT_MAJOR = new Array(12)
+const CAMELOT_MINOR = new Array(12)
+for (let step = 0; step < 12; step++) {
+  const num = ((8 + step - 1) % 12) + 1          // 8, 9, …, 12, 1, …, 7
+  CAMELOT_MAJOR[(0 + 7 * step) % 12] = `${num}B` // C, G, D, …
+  CAMELOT_MINOR[(9 + 7 * step) % 12] = `${num}A` // Am, Em, Bm, …
+}
+
+export function toCamelot (pitchClass, mode) {
+  const pc = ((pitchClass % 12) + 12) % 12
+  return mode === MODE_MAJOR ? CAMELOT_MAJOR[pc] : CAMELOT_MINOR[pc]
+}
+
+// Open Key notation (Traktor): same wheel, 1d = C major / 1m = A minor.
+export function toOpenKey (pitchClass, mode) {
+  const camelot = toCamelot(pitchClass, mode)
+  const num = parseInt(camelot, 10)
+  const openNum = ((num + 5 - 1) % 12) + 1
+  return `${openNum}${mode === MODE_MAJOR ? 'd' : 'm'}`
+}
+
+export function keyLabel (pitchClass, mode) {
+  const pc = ((pitchClass % 12) + 12) % 12
+  return { note: NOTE_NAMES[pc], mode }
+}
+
+// Relative major/minor (shares the same key signature).
+export function relativeKey (pitchClass, mode) {
+  const pc = ((pitchClass % 12) + 12) % 12
+  return mode === MODE_MAJOR
+    ? { pitchClass: (pc + 9) % 12, mode: MODE_MINOR }
+    : { pitchClass: (pc + 3) % 12, mode: MODE_MAJOR }
+}
+
+// Musical relationship between two keys, for explaining alternatives.
+// Returns 'same' | 'relative' | 'fifth' | 'parallel' | 'other'.
+export function keyRelationship (a, b) {
+  if (a.mode === b.mode && a.pitchClass === b.pitchClass) return 'same'
+  const rel = relativeKey(a.pitchClass, a.mode)
+  if (rel.pitchClass === b.pitchClass && rel.mode === b.mode) return 'relative'
+  if (a.mode === b.mode) {
+    const d = ((b.pitchClass - a.pitchClass) % 12 + 12) % 12
+    if (d === 7 || d === 5) return 'fifth'
+  }
+  if (a.mode !== b.mode && a.pitchClass === b.pitchClass) return 'parallel'
+  return 'other'
+}
+
+// Produced music sits on integer (or half-integer) BPM almost always.
+// Snap when close; otherwise keep one decimal so odd tempos stay honest.
+export function snapBpm (bpm) {
+  if (!Number.isFinite(bpm) || bpm <= 0) return { value: 0, display: '—' }
+  const nearestInt = Math.round(bpm)
+  if (Math.abs(bpm - nearestInt) <= 0.25) {
+    return { value: nearestInt, display: String(nearestInt) }
+  }
+  const nearestHalf = Math.round(bpm * 2) / 2
+  if (Math.abs(bpm - nearestHalf) <= 0.12) {
+    return { value: nearestHalf, display: nearestHalf.toFixed(1) }
+  }
+  const oneDec = Math.round(bpm * 10) / 10
+  return { value: oneDec, display: oneDec.toFixed(1) }
+}
+
+// Fold a BPM into [lo, hi) by octave (×2 / ÷2) — used to compare candidates
+// that describe the same pulse at different metrical levels.
+export function foldBpm (bpm, lo = 85, hi = 170) {
+  if (!Number.isFinite(bpm) || bpm <= 0) return bpm
+  let b = bpm
+  while (b >= hi) b /= 2
+  while (b < lo) b *= 2
+  return b
+}

--- a/frontend/src/utils/tempoEngine.js
+++ b/frontend/src/utils/tempoEngine.js
@@ -1,0 +1,489 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Tempo engine — professional-grade BPM estimation.
+//
+// Method (faithful to published, benchmark-validated designs):
+//   1. Onset Strength Signal (OSS), full band + low band: log-compressed
+//      spectral flux, low-passed and detrended       (Percival & Tzanetakis 2014)
+//   2. Beat period: generalized autocorrelation with harmonic enhancement,
+//      estimated on overlapping ~12 s windows and accumulated into a kernel
+//      density over BPM → track-wide consistency vote (Percival & Tzanetakis 2014)
+//   3. Metrical level (octave) decision: pulse-train combs on the kick/bass
+//      band — fastest level with every beat anchored wins; composite
+//      on/off-beat structure × a wide log-tempo prior as fallback
+//   4. Verification & refinement: dynamic-programming beat tracking
+//      (Ellis 2007, as in librosa) → inlier-mean inter-beat interval, beat
+//      salience and regularity feed an honest confidence score.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { fft, hannWindow, generalizedACF, lowpassFIR, movingMean, parabolicPeak, sampleAt } from './dsp.js'
+
+const MIN_BPM = 50
+const MAX_BPM = 210
+
+// ─── 1. Onset Strength Signal (full band + low band) ────────────────────────
+// The low band (< 160 Hz — kick and bass fundamentals) is computed alongside:
+// the tactus that commercial tools report is the one every kick/bass event
+// marks, which is what disambiguates 128 vs 64 BPM.
+const LOW_BAND_HZ = 160
+
+function postProcessOSS (raw, ossSr) {
+  const smoothed = lowpassFIR(raw, 8 / ossSr, 21)
+  const trend = movingMean(smoothed, Math.round(ossSr * 0.75))
+  const out = new Float32Array(raw.length)
+  for (let i = 0; i < raw.length; i++) out[i] = Math.max(0, smoothed[i] - trend[i])
+  return out
+}
+
+export function computeOSS (pcm, sr) {
+  // Frame ≈ 46 ms, hop = frame/8 → OSS rate ≈ 172 Hz at 22 050 Hz input.
+  let frame = 1
+  while (frame < sr * 0.0464) frame <<= 1
+  const hop = frame >> 3
+  const half = frame >> 1
+  const n = pcm.length
+  const nFrames = Math.max(0, Math.floor((n - frame) / hop) + 1)
+  const ossSr = sr / hop
+
+  const win = hannWindow(frame)
+  const re = new Float64Array(frame)
+  const im = new Float64Array(frame)
+  const prev = new Float32Array(half)
+  const oss = new Float32Array(nFrames)
+  const ossLow = new Float32Array(nFrames)
+  const lowBins = Math.max(2, Math.ceil((LOW_BAND_HZ * frame) / sr))
+
+  for (let f = 0; f < nFrames; f++) {
+    const off = f * hop
+    for (let i = 0; i < frame; i++) { re[i] = pcm[off + i] * win[i]; im[i] = 0 }
+    fft(re, im)
+
+    let flux = 0
+    let fluxLow = 0
+    for (let k = 1; k < half; k++) {
+      const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k])
+      const lm = Math.log1p(100 * mag)
+      const d = lm - prev[k]
+      if (d > 0 && f > 0) {
+        flux += d
+        if (k <= lowBins) fluxLow += d
+      }
+      prev[k] = lm
+    }
+    oss[f] = flux
+    ossLow[f] = fluxLow
+  }
+
+  if (nFrames === 0) return { oss, ossLow, ossSr }
+  return { oss: postProcessOSS(oss, ossSr), ossLow: postProcessOSS(ossLow, ossSr), ossSr }
+}
+
+// ─── 2. Per-window beat period via enhanced generalized ACF ─────────────────
+function windowPeriodEstimate (ossWin, ossSr) {
+  const acf = generalizedACF(ossWin, 1)
+  const minLag = Math.max(2, Math.floor((60 / MAX_BPM) * ossSr))
+  const maxLag = Math.min(ossWin.length - 1, Math.ceil((60 / MIN_BPM) * ossSr))
+  if (maxLag - minLag < 4) return null
+
+  // Harmonic enhancement: a true beat lag is supported by peaks at its
+  // multiples; search each multiple within a small tolerance window.
+  const HARMONICS = [[1, 1.0], [2, 0.75], [3, 0.3], [4, 0.5]]
+  const score = new Float64Array(maxLag + 1)
+  const nAcf = acf.length
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let s = 0
+    let wSum = 0
+    for (const [m, w] of HARMONICS) {
+      const center = m * lag
+      if (center >= nAcf) break
+      const tol = Math.max(1, Math.round(0.015 * center))
+      let best = -Infinity
+      const lo = Math.max(0, center - tol)
+      const hi = Math.min(nAcf - 1, center + tol)
+      for (let i = lo; i <= hi; i++) if (acf[i] > best) best = acf[i]
+      s += w * best
+      wSum += w
+    }
+    score[lag] = wSum > 0 ? s / wSum : 0
+  }
+
+  let bestLag = minLag
+  for (let lag = minLag + 1; lag <= maxLag; lag++) {
+    if (score[lag] > score[bestLag]) bestLag = lag
+  }
+  const { pos, val } = parabolicPeak(score, bestLag)
+  if (!(val > 0)) return null
+  return { bpm: (60 * ossSr) / pos, strength: val }
+}
+
+// Accumulate window estimates into a kernel density over BPM.
+function tempoKDE (estimates) {
+  const step = 0.25
+  const nBins = Math.floor((MAX_BPM - MIN_BPM) / step) + 1
+  const kde = new Float64Array(nBins)
+  for (const { bpm, strength } of estimates) {
+    const sigma = Math.max(0.75, 0.02 * bpm)
+    const lo = Math.max(0, Math.floor((bpm - 4 * sigma - MIN_BPM) / step))
+    const hi = Math.min(nBins - 1, Math.ceil((bpm + 4 * sigma - MIN_BPM) / step))
+    for (let i = lo; i <= hi; i++) {
+      const b = MIN_BPM + i * step
+      const z = (b - bpm) / sigma
+      kde[i] += strength * Math.exp(-0.5 * z * z)
+    }
+  }
+  return { kde, step }
+}
+
+// ─── 3. Pulse-train level metrics (metrical level decision) ─────────────────
+// A band is a usable beat anchor when it is *impulsive*: sparse strong events
+// over near-silence (kicks/bass), not a dense wash (hats fill every eighth in
+// the full band, which is exactly why it cannot decide the metrical level).
+export function bandIsImpulsive (x) {
+  const n = x.length
+  if (n < 16) return false
+  const sorted = Float32Array.from(x).sort()
+  const median = sorted[n >> 1]
+  const p90 = sorted[Math.floor(n * 0.9)]
+  let mean = 0
+  for (let i = 0; i < n; i++) mean += x[i]
+  mean /= n
+  return mean > 1e-9 && p90 > 4 * Math.max(median, mean * 0.02)
+}
+
+// Samples the anchor signal on a comb at the candidate period, at the phase
+// with the strongest on-beat mean, and measures:
+//   · support  — weakest ~30 % of comb slots vs their median. ≈1 when every
+//     beat is marked, ≈0 when the comb has empty slots (the candidate
+//     subdivides the real pulse).
+//   · offRatio — energy at half-period offsets vs on-beat energy. ≈1 means
+//     the off positions are real beats too → the true tactus is faster.
+//   · onCV — variation across on-beat samples; high alternation means the
+//     true tactus is slower.
+function pulseSpanMetrics (sig, ossSr, bpm) {
+  const period = (60 / bpm) * ossSr
+  const n = sig.length
+  const nBeats = Math.floor((n - 1) / period)
+  if (nBeats < 4) return null
+
+  let globalMean = 0
+  for (let i = 0; i < n; i++) globalMean += sig[i]
+  globalMean /= n
+  if (globalMean <= 1e-9) return null
+
+  const N_PHASES = 24
+  let best = null
+  const samples = []
+  for (let p = 0; p < N_PHASES; p++) {
+    const phase = (p * period) / N_PHASES
+    let on = 0
+    let on2 = 0
+    let off = 0
+    let count = 0
+    samples.length = 0
+    for (let k = 0; k * period + phase < n - 1; k++) {
+      const pos = phase + k * period
+      const v = sampleAt(sig, pos)
+      on += v
+      on2 += v * v
+      samples.push(v)
+      off += sampleAt(sig, Math.min(n - 1, pos + 0.5 * period))
+      count++
+    }
+    if (count < 4) continue
+    const onMean = on / count
+    if (best && onMean <= best.onMean) continue
+
+    off /= count
+    const variance = Math.max(0, on2 / count - onMean * onMean)
+    const onCV = onMean > 1e-9 ? Math.sqrt(variance) / onMean : 1
+    const offRatio = Math.min(1, off / Math.max(onMean, 1e-9))
+
+    samples.sort((a, b) => a - b)
+    const kWeak = Math.max(1, Math.floor(samples.length * 0.3))
+    let weak = 0
+    for (let i = 0; i < kWeak; i++) weak += samples[i]
+    weak /= kWeak
+    const median = samples[Math.floor(samples.length / 2)]
+    const support = median > 1e-9 ? Math.min(1, weak / median) : 0
+
+    best = {
+      onMean,
+      onMeanN: onMean / globalMean,
+      offRatio,
+      onCV,
+      support,
+      composite: (onMean / globalMean) * (1 - 0.45 * offRatio) * (1 - 0.3 * Math.min(1, onCV)),
+    }
+  }
+  return best
+}
+
+// The comb dephases over long excerpts (a 0.3 % tempo error drifts a full
+// beat in ~30 s), so metrics are measured on up to three short spans and
+// combined by median — robust to one span landing on a breakdown.
+function pulseLevelMetrics (sig, ossSr, bpm) {
+  const spanLen = Math.min(sig.length, Math.round(15 * ossSr))
+  const starts = sig.length <= spanLen
+    ? [0]
+    : [0, Math.floor((sig.length - spanLen) / 2), sig.length - spanLen]
+  const spans = []
+  for (const s of starts) {
+    const m = pulseSpanMetrics(sig.subarray(s, s + spanLen), ossSr, bpm)
+    if (m) spans.push(m)
+  }
+  if (spans.length === 0) return null
+  const med = (key) => {
+    const v = spans.map(s => s[key]).sort((a, b) => a - b)
+    return v[Math.floor(v.length / 2)]
+  }
+  return {
+    onMeanN: med('onMeanN'),
+    offRatio: med('offRatio'),
+    onCV: med('onCV'),
+    support: med('support'),
+    composite: med('composite'),
+  }
+}
+
+// Wide log-normal prior over tempo (σ = 0.9 octaves around 120 BPM): breaks
+// exact ties toward perceptually common tempos without vetoing extremes.
+function tempoPrior (bpm) {
+  const z = Math.log2(bpm / 120) / 0.9
+  return Math.exp(-0.5 * z * z)
+}
+
+// ─── 4. Dynamic-programming beat tracking (Ellis 2007) ──────────────────────
+export function trackBeats (oss, ossSr, bpm, tightness = 100) {
+  const n = oss.length
+  const tau = (60 / bpm) * ossSr
+  if (n < tau * 3) return null
+
+  // Normalize local score to mean 1 so the tightness penalty is scale-free.
+  let mean = 0
+  for (let i = 0; i < n; i++) mean += oss[i]
+  mean /= n
+  if (mean <= 1e-9) return null
+  const O = new Float64Array(n)
+  for (let i = 0; i < n; i++) O[i] = oss[i] / mean
+
+  const minD = Math.max(1, Math.round(0.5 * tau))
+  const maxD = Math.min(n - 1, Math.round(2 * tau))
+  const C = new Float64Array(n)
+  const ptr = new Int32Array(n).fill(-1)
+
+  for (let t = 0; t < n; t++) {
+    let bestScore = 0
+    let bestPrev = -1
+    if (t >= minD) {
+      const dHi = Math.min(maxD, t)
+      for (let d = minD; d <= dHi; d++) {
+        const logRatio = Math.log(d / tau)
+        const s = C[t - d] - tightness * logRatio * logRatio
+        if (s > bestScore) { bestScore = s; bestPrev = t - d }
+      }
+    }
+    C[t] = O[t] + bestScore
+    ptr[t] = bestPrev
+  }
+
+  // Best chain ending near the end of the signal.
+  let end = n - 1
+  const searchFrom = Math.max(0, n - Math.round(tau * 1.5))
+  for (let t = searchFrom; t < n; t++) if (C[t] > C[end]) end = t
+
+  const beats = []
+  for (let t = end; t >= 0; t = ptr[t]) {
+    beats.push(t)
+    if (ptr[t] < 0) break
+  }
+  beats.reverse()
+  if (beats.length < 4) return null
+
+  const ibis = []
+  for (let i = 1; i < beats.length; i++) ibis.push(beats[i] - beats[i - 1])
+  const sorted = [...ibis].sort((a, b) => a - b)
+  const median = sorted[Math.floor(sorted.length / 2)]
+  const q1 = sorted[Math.floor(sorted.length * 0.25)]
+  const q3 = sorted[Math.floor(sorted.length * 0.75)]
+  const iqrCV = median > 0 ? (q3 - q1) / median : 1
+
+  // Beat times are integer OSS frames; the median IBI inherits that
+  // quantization (~0.6 % at 128 BPM). The mean over inlier IBIs recovers
+  // sub-frame precision.
+  let ibiSum = 0
+  let ibiCount = 0
+  for (const d of ibis) {
+    if (Math.abs(d - median) <= Math.max(2, median * 0.04)) { ibiSum += d; ibiCount++ }
+  }
+  const refined = ibiCount > 0 ? ibiSum / ibiCount : median
+
+  let onBeat = 0
+  for (const b of beats) onBeat += O[b]
+  onBeat /= beats.length
+
+  return {
+    bpm: (60 * ossSr) / refined,
+    nBeats: beats.length,
+    ibiCV: iqrCV,
+    beatSalience: onBeat, // vs mean 1
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+export function estimateTempo (pcm, sr, { onProgress } = {}) {
+  const report = (p) => { if (onProgress) onProgress(p) }
+
+  // Cap analysis to the central 3 minutes: plenty of evidence, bounded CPU.
+  const maxSamples = Math.floor(180 * sr)
+  let segment = pcm
+  if (pcm.length > maxSamples) {
+    const start = Math.floor((pcm.length - maxSamples) / 2)
+    segment = pcm.subarray(start, start + maxSamples)
+  }
+
+  const { oss, ossLow, ossSr } = computeOSS(segment, sr)
+  report(0.45)
+
+  const empty = { bpm: 0, confidence: 0, alt: null, metrics: null }
+  if (oss.length < ossSr * 3) return empty
+  let energy = 0
+  for (let i = 0; i < oss.length; i++) energy += oss[i]
+  if (energy / oss.length < 1e-6) return empty
+
+  // Windowed period estimates → KDE vote across the whole excerpt.
+  const WIN = 2048
+  const HOP = 512
+  const estimates = []
+  if (oss.length <= WIN) {
+    const e = windowPeriodEstimate(oss, ossSr)
+    if (e) estimates.push(e)
+  } else {
+    for (let start = 0; start + WIN <= oss.length; start += HOP) {
+      const e = windowPeriodEstimate(oss.subarray(start, start + WIN), ossSr)
+      if (e) estimates.push(e)
+    }
+  }
+  if (estimates.length === 0) return empty
+  report(0.65)
+
+  const kdeObj = tempoKDE(estimates)
+  const { kde, step } = kdeObj
+  let peakIdx = 0
+  for (let i = 1; i < kde.length; i++) if (kde[i] > kde[peakIdx]) peakIdx = i
+  const { pos } = parabolicPeak(kde, peakIdx)
+  let baseBpm = MIN_BPM + pos * step
+
+  // Micro-refine the base period (±1.2 % grid) by maximizing comb alignment
+  // on a central span: the KDE quantization (~0.3 %) would otherwise dephase
+  // the pulse combs used for the level decision below.
+  {
+    const spanLen = Math.min(oss.length, Math.round(15 * ossSr))
+    const mid = oss.subarray(
+      Math.floor((oss.length - spanLen) / 2),
+      Math.floor((oss.length - spanLen) / 2) + spanLen
+    )
+    let bestOn = -1
+    let bestBpm = baseBpm
+    for (let s = -4; s <= 4; s++) {
+      const b = baseBpm * (1 + 0.003 * s)
+      const m = pulseSpanMetrics(mid, ossSr, b)
+      if (m && m.onMean > bestOn) { bestOn = m.onMean; bestBpm = b }
+    }
+    baseBpm = bestBpm
+  }
+
+  // Candidate metrical levels of the base tempo. The KDE already fixed the
+  // period *family*; the level itself is decided by pulse-train structure on
+  // the most informative band: kick/bass when impulsive low-band content
+  // exists (hats fill every eighth in the full band and would mask the level).
+  const hasLow = bandIsImpulsive(ossLow)
+  const anchorSig = hasLow ? ossLow : oss
+  const RATIOS = [[0.5, 1.0], [2 / 3, 0.85], [1, 1.0], [1.5, 0.85], [2, 1.0]]
+  const candidates = []
+  for (const [ratio, penalty] of RATIOS) {
+    const bpm = baseBpm * ratio
+    if (bpm < MIN_BPM || bpm > MAX_BPM) continue
+    if (candidates.some(c => Math.abs(c.bpm - bpm) / bpm < 0.02)) continue
+    const m = pulseLevelMetrics(anchorSig, ossSr, bpm)
+    if (!m) continue
+    candidates.push({
+      bpm,
+      lvl: m,
+      score: penalty * m.composite * (0.4 + 0.6 * tempoPrior(bpm)),
+    })
+  }
+  if (candidates.length === 0) return empty
+
+  // Hierarchical decision: prefer the fastest level whose every beat is
+  // anchored by kick/bass events — that is the tactus DJs and commercial
+  // tools label. Without solid low-band evidence, fall back to the composite
+  // pulse score × prior.
+  const supported = hasLow
+    ? candidates.filter(c => c.lvl.support >= 0.45 && c.lvl.onCV <= 0.6)
+    : []
+  const byScore = [...candidates].sort((a, b) => b.score - a.score)
+  if (globalThis.__TEMPO_DEBUG) {
+    console.log(`  base=${baseBpm.toFixed(1)} hasLow=${hasLow}`)
+    for (const c of candidates) {
+      console.log(`  cand ${c.bpm.toFixed(1).padStart(6)}  sup=${c.lvl.support.toFixed(2)} onCV=${c.lvl.onCV.toFixed(2)} offR=${c.lvl.offRatio.toFixed(2)} onN=${c.lvl.onMeanN.toFixed(2)} comp=${c.lvl.composite.toFixed(3)} score=${c.score.toFixed(3)}`)
+    }
+  }
+  const supportDecided = supported.length > 0
+  const winner = supportDecided
+    ? supported.reduce((a, b) => (b.bpm > a.bpm ? b : a))
+    : byScore[0]
+  const runnerUp = byScore.find(c => c !== winner) || null
+  report(0.8)
+
+  // Verify and refine with DP beat tracking.
+  let bpm = winner.bpm
+  const dpSpan = oss.length > ossSr * 120 ? oss.subarray(0, Math.floor(ossSr * 120)) : oss
+  const beat = trackBeats(dpSpan, ossSr, bpm)
+  let beatSalience = 0
+  let ibiCV = 1
+  if (beat) {
+    if (Math.abs(beat.bpm - bpm) / bpm < 0.035) bpm = beat.bpm
+    beatSalience = beat.beatSalience
+    ibiCV = beat.ibiCV
+  }
+  report(0.95)
+
+  // Honest confidence from independent evidence:
+  //  · periodicity — absolute strength of the enhanced ACF peaks; gates the
+  //    whole score so aperiodic material can never look confident
+  //  · agreement — share of window votes metrically consistent with the result
+  //  · salience  — how much onset energy concentrates on the tracked beats
+  //  · stability — inter-beat regularity
+  //  · levelCert — margin of the metrical-level decision
+  let agreeW = 0
+  let totalW = 0
+  for (const { bpm: b, strength } of estimates) {
+    totalW += strength
+    for (const r of [0.25, 1 / 3, 0.5, 2 / 3, 0.75, 1, 4 / 3, 1.5, 2, 3, 4]) {
+      if (Math.abs(b * r - bpm) / bpm < 0.045) { agreeW += strength; break }
+    }
+  }
+  const agreement = totalW > 0 ? agreeW / totalW : 0
+  const strengths = estimates.map(e => e.strength).sort((a, b) => a - b)
+  const medStrength = strengths[Math.floor(strengths.length / 2)]
+  const periodicity = Math.min(1, Math.max(0.1, (medStrength - 0.05) / 0.22))
+  const salienceN = Math.min(1, Math.max(0, (beatSalience - 1) / 2.2))
+  const stability = 1 - Math.min(1, ibiCV * 7)
+  const levelCert = supportDecided
+    ? 0.5 + 0.5 * Math.min(1, (winner.lvl.support - 0.45) / 0.35)
+    : (runnerUp && runnerUp.score > 0 ? winner.score / (winner.score + runnerUp.score) : 1)
+  const confidence = Math.round(Math.min(98, Math.max(5,
+    100 * periodicity * (0.34 * agreement + 0.30 * salienceN + 0.20 * stability + 0.16 * levelCert)
+  )))
+
+  // Surface the runner-up level when the decision was genuinely close.
+  const alt = !supportDecided && runnerUp && runnerUp.score > winner.score * 0.72
+    ? runnerUp.bpm
+    : null
+
+  return {
+    bpm,
+    confidence,
+    alt,
+    metrics: { agreement, beatSalience, ibiCV, levelCert, medStrength, windows: estimates.length },
+  }
+}

--- a/frontend/src/workers/audioAnalysis.worker.js
+++ b/frontend/src/workers/audioAnalysis.worker.js
@@ -1,0 +1,16 @@
+// Web Worker host for the audio analysis engine: keeps the heavy DSP off the
+// main thread and streams progress back to the UI.
+import { analyzeAudioData } from '../utils/audioEngine.js'
+
+self.onmessage = (e) => {
+  const { id, pcm, sampleRate, duration } = e.data
+  try {
+    const result = analyzeAudioData(pcm, sampleRate, {
+      duration,
+      onProgress: ({ stage, pct }) => self.postMessage({ id, type: 'progress', stage, pct }),
+    })
+    self.postMessage({ id, type: 'result', result })
+  } catch (err) {
+    self.postMessage({ id, type: 'error', message: err && err.message ? err.message : String(err) })
+  }
+}


### PR DESCRIPTION
## Resumen

Sustituye el detector de BPM/tonalidad del panel de herramientas (poco fiable) por un motor DSP propio de nivel profesional, implementando fielmente algoritmos publicados y validados en benchmarks académicos, sin dependencias nuevas.

> Se evaluó usar essentia.js (el estándar académico en WASM), pero su licencia **AGPL-3.0** obligaría a liberar el código del frontend. El motor propio implementa los mismos métodos publicados y deja el código limpio de copyleft.

## Motor de tempo (`tempoEngine.js`)

- Envolvente de onsets por flux espectral log-comprimido, en banda completa **y banda grave** (<160 Hz), suavizada y sin tendencia (Percival & Tzanetakis 2014).
- Periodo por autocorrelación generalizada con realce armónico, votada en ventanas de ~12 s y acumulada en una densidad KDE sobre BPM (consistencia a lo largo de la pista).
- **Decisión de nivel métrico** (¿128 o 64?) por trenes de pulsos anclados en bombo/bajo: gana el nivel más rápido con todos los beats respaldados; fallback por estructura on/off-beat × prior logarítmico ancho. Es la regla que reproduce el etiquetado de las herramientas comerciales (house 128, DnB 174).
- Verificación con beat-tracking por programación dinámica (Ellis 2007, como librosa) y refinado por media de intervalos inliers (precisión sub-frame).
- Snap musical: enteros y medios BPM (87.5) cuando procede, un decimal si no.

## Motor de tonalidad (`keyEngine.js`)

- Picos espectrales con interpolación cuadrática (precisión sub-bin).
- **Estimación de afinación**: histograma de desviaciones respecto a A=440 — las pistas desafinadas ya no emborronan el chroma (se muestra en la UI).
- HPCP de 36 bins con suma armónica (Gómez 2006), gating de silencio y normalización por frame.
- Ensemble de 4 perfiles publicados: Krumhansl, Temperley, **EDMA** y **bgate** (corpus Beatport — los más fuertes en electrónica), con votación temporal por bloques de 20 s: la tonalidad debe ganar global y consistentemente.
- Notación **Camelot** y Open Key para mezcla armónica; alternativa mostrada (relativa/quinta) cuando el margen es estrecho.

## Integración

- Análisis en **Web Worker** (chunk de 16 kB) con progreso por etapas; fallback al mismo motor en hilo principal si el worker falla.
- Errores tipados (audio en silencio / demasiado corto) con mensajes claros.
- Confianzas honestas: puerta de periodicidad absoluta — el ruido sin música reporta ~6 %, no 90 %.
- UI: barra de progreso real, chip Camelot, BPM/tonalidad alternativos, afinación detectada.

## Validación con ground truth (`npm run validate:audio`)

Suite que sintetiza pistas multigénero (batería + bajo + acordes + arpegios, con humanización determinista) de BPM y tonalidad conocidos:

| Caso | Resultado |
|---|---|
| House 128 / Techno 140 / Dance 110 / Breaks 150 | BPM y tonalidad exactos |
| Hip-hop 95 (swing) / Downtempo 70 | exactos |
| Halftime **87.5** (BPM no entero) | exacto |
| DnB **174** (estrés de octava) | 174 ✓ con alternativa 87 expuesta |
| Trance 138 con bajo en corcheas | exacto |
| Desafinado +30/−25 cents | tonalidad exacta y afinación recuperada al cent |
| Intro de 20 s sin ritmo | exacto |
| Loop Axis (ambigüedad relativa real) | relativa correcta |
| Sin batería / ruido / silencio / clip corto | degradación honesta y errores tipados |

**16/16 casos pasan.** Tests Jest nuevos: 14 (teoría musical + motor end-to-end). ~0.5 s de análisis por pista de 50 s.

## Notas

- Las 3 suites de Spotify que fallan al cargar (`import.meta.env` con babel-jest) ya fallaban en `main` — preexistente, fuera del alcance de este PR.
- `scripts/debug-tempo.mjs` imprime las métricas por candidato (guardado tras `globalThis.__TEMPO_DEBUG`) para futuros ajustes.
