### PR TITLE
feat: unifica el crédito de autoría en el footer

### DIFF
--- a/frontend/src/components/Footer/Footer.jsx
+++ b/frontend/src/components/Footer/Footer.jsx
@@ -164,8 +164,8 @@ function Footer () {
         <div className="footer-bottom">
           <span className="footer-bottom__item">© {year} Other People Records</span>
           <span className="footer-bottom__item footer-bottom__author">
-            Diseño + código por{' '}
-            <a href="https://alexalvarez.dev" target="_blank" rel="noopener noreferrer">
+            Diseñado y Desarrollado por{' '}
+            <a href="https://www.alexalvarez.dev" target="_blank" rel="noopener noreferrer">
               alexalvarez.dev
             </a>
           </span>


### PR DESCRIPTION
Unifica el crédito del pie con el del resto de webs del portfolio: **Diseñado y Desarrollado por alexalvarez.dev**, con el enlace apuntando a https://www.alexalvarez.dev (antes iba sin `www`).

Solo cambia el texto y el href; el marcado y los estilos se mantienen.