### PR TITLE
fix(seo): pagina el sitemap, la API rechaza count > 100

### DIFF
--- a/frontend/api/sitemap.js
+++ b/frontend/api/sitemap.js
@@ -67,19 +67,48 @@ function urlEntry ({ path, priority, changefreq, lastmod }) {
   ].filter(Boolean).join('\n')
 }
 
-/** Descarga una colección de la API. Devuelve [] ante cualquier problema. */
+// La API rechaza con 400 cualquier count > 100, así que paginamos.
+const PAGE_SIZE = 100
+// Tope de seguridad: 20 páginas son 2000 fichas, muy por encima del catálogo
+// real. Evita un bucle infinito si la paginación de la API se comporta raro.
+const MAX_PAGES = 20
+
+/**
+ * Descarga una colección completa de la API paginando de 100 en 100.
+ * Devuelve lo que haya conseguido hasta el momento del fallo: un sitemap
+ * incompleto es mejor que un 500 que Search Console marque como error.
+ */
 async function fetchCollection (endpoint) {
-  try {
-    const res = await fetch(`${API_URL}/${endpoint}?count=500&page=1`, {
-      headers: { accept: 'application/json' }
-    })
-    if (!res.ok) return []
-    const body = await res.json()
-    const list = body.data || body[endpoint] || body
-    return Array.isArray(list) ? list : []
-  } catch {
-    return []
+  const items = []
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    let body
+    try {
+      const res = await fetch(`${API_URL}/${endpoint}?count=${PAGE_SIZE}&page=${page}`, {
+        headers: { accept: 'application/json' }
+      })
+      if (!res.ok) {
+        console.error(`[sitemap] ${endpoint} p${page}: HTTP ${res.status}`)
+        break
+      }
+      body = await res.json()
+    } catch (err) {
+      console.error(`[sitemap] ${endpoint} p${page}: ${err.message}`)
+      break
+    }
+
+    const list = body?.data || body?.[endpoint] || body
+    if (!Array.isArray(list) || list.length === 0) break
+
+    items.push(...list)
+
+    // Preferimos el total de páginas que declara la API; si no viene, paramos
+    // en cuanto una página llega incompleta.
+    const totalPages = body?.pagination?.pages
+    if (totalPages ? page >= totalPages : list.length < PAGE_SIZE) break
   }
+
+  return items
 }
 
 export default async function handler (req, res) {


### PR DESCRIPTION
Verificando la #34 ya en producción, el sitemap devolvía **solo las 16 rutas estáticas**: ni una ficha de artista, evento o beat.

## Causa

`api/sitemap.js` pedía cada colección con `count=500`, y la API responde 400:

```
$ curl 'https://otp-web-back.vercel.app/api/artists?count=500&page=1'
{"error":"Invalid filter parameters","details":["count cannot exceed 100"]}
```

El `catch` genérico devolvía `[]`, así que el fallo no dejaba rastro en ningún sitio y el sitemap salía "correcto" pero vacío de contenido.

## Arreglo

- Pagina de 100 en 100 usando `pagination.pages`, con parada alternativa cuando una página llega incompleta.
- Tope de 20 páginas como red de seguridad contra un bucle infinito.
- `console.error` en cada página que falla, en vez de tragarse el error. Se mantiene la devolución parcial: un sitemap incompleto sigue siendo mejor que un 500 que Search Console marque como error.

## Verificación

Ejecutado contra la API de producción real:

| | antes | después |
|---|---|---|
| URLs totales | 16 | **106** |
| artistas | 0 | 12 |
| eventos | 0 | 13 |
| beats | 0 | 65 |

90 de esas URLs llevan `lastmod`.

## Lo que sí funcionaba

Comprobado también en producción tras el merge de la #34:

- `/robots.txt` → 200 `text/plain` con el contenido correcto (antes devolvía el HTML de la SPA).
- `/sitemap.xml` → 200 `application/xml`.
- HTML para Googlebot en las fichas: `curl -A Googlebot https://www.otherpeople.es/artistas/<id>` devuelve título real, description, canonical y JSON-LD. La función `api/og.js` volvió a estar viva tras moverla a `frontend/api/`.
